### PR TITLE
Integrate Alamofire networking library

### DIFF
--- a/Split.podspec
+++ b/Split.podspec
@@ -17,5 +17,6 @@ This SDK is designed to work with Split, the platform for controlled rollouts, s
   s.tvos.deployment_target = '9.0'
   s.source_files = 'Split/**/*'
   s.frameworks = 'Foundation'
+  s.dependency 'Alamofire', '4.5'
   s.source_files = 'Split/*.{swift}'
 end


### PR DESCRIPTION
## Background

We need to integrate a networking library to make requests to the Callhome

## Changes done

- Added Alamofire 4.5 dependency to the .podspecs file

## Reviewers required

@patricioe @sarrubia 