### PR TITLE
Add networking layer and treatments endpoint implementation

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,11 +1,13 @@
 use_frameworks!
 
 target 'Split_Example' do
+    
+  pod 'Split', :path => '../'
+
   target 'Split_Tests' do
   
     pod 'Quick', '~> 1.0.0'
     pod 'Nimble', '~> 5.1.1'
-    pod 'Split', :path => '../'
 
     post_install do |installer|
         installer.pods_project.targets.each do |target|

--- a/Example/Split.xcodeproj/project.pbxproj
+++ b/Example/Split.xcodeproj/project.pbxproj
@@ -7,14 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		087AAC2E222B3A6A92D5DE18 /* Pods_Split_Example_Split_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E862A556841E8C60069A4B61 /* Pods_Split_Example_Split_Tests.framework */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
-		81B34462B19ED946FC4CCC71 /* Pods_Split_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 382E3E34D54A1D485297F610 /* Pods_Split_Example.framework */; };
+		63921D5F780CE4DBD840F0D8 /* Pods_Split_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 441D254060332D10C49E0F46 /* Pods_Split_Example.framework */; };
+		6624CA25DEA2C8AE5899C1DC /* Pods_Split_Example_Split_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14946A7643C6298E66BB0478 /* Pods_Split_Example_Split_Tests.framework */; };
+		D39460CC1F71D09A000396FC /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39460CA1F71D09A000396FC /* Nimble.framework */; };
+		D39460CD1F71D09A000396FC /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39460CB1F71D09A000396FC /* Quick.framework */; };
+		D39460CE1F71D215000396FC /* Split.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D39460BB1F71C7F5000396FC /* Split.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -28,7 +31,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		382E3E34D54A1D485297F610 /* Pods_Split_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Split_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		14946A7643C6298E66BB0478 /* Pods_Split_Example_Split_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Split_Example_Split_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		441D254060332D10C49E0F46 /* Pods_Split_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Split_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58CFD60B6F2902D3FC84E8C7 /* Pods-Split_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Split_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Split_Example/Pods-Split_Example.release.xcconfig"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* Split_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Split_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -46,7 +50,14 @@
 		91A0F086A5FB0C0B797E8F76 /* Pods-Split_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Split_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Split_Tests/Pods-Split_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		9ED7384CAA90FDAC9C10386A /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		9F0F3C55FDC0A4DBF30265DD /* Pods-Split_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Split_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Split_Tests/Pods-Split_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		E862A556841E8C60069A4B61 /* Pods_Split_Example_Split_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Split_Example_Split_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D39460BB1F71C7F5000396FC /* Split.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Split.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/Split/Split.framework"; sourceTree = "<group>"; };
+		D39460BD1F71C812000396FC /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/Alamofire/Alamofire.framework"; sourceTree = "<group>"; };
+		D39460BE1F71C812000396FC /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/Nimble/Nimble.framework"; sourceTree = "<group>"; };
+		D39460BF1F71C812000396FC /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/Quick/Quick.framework"; sourceTree = "<group>"; };
+		D39460C01F71C812000396FC /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/SwiftyJSON/SwiftyJSON.framework"; sourceTree = "<group>"; };
+		D39460C61F71CA72000396FC /* Pods_Split_Example.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_Split_Example.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/Split-djpyfxmmdiklrzaobkgqhweqysyv/Build/Products/Debug-iphonesimulator/Pods_Split_Example.framework"; sourceTree = "<group>"; };
+		D39460CA1F71D09A000396FC /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = "Pods/../build/Debug-iphoneos/Nimble/Nimble.framework"; sourceTree = "<group>"; };
+		D39460CB1F71D09A000396FC /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = "Pods/../build/Debug-iphoneos/Quick/Quick.framework"; sourceTree = "<group>"; };
 		ECDBBDA20B47946E5EAFE113 /* Pods-Split_Example-Split_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Split_Example-Split_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Split_Example-Split_Tests/Pods-Split_Example-Split_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		F3DAE28ED41D8C8D9A711BC6 /* Split.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Split.podspec; path = ../Split.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -56,7 +67,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81B34462B19ED946FC4CCC71 /* Pods_Split_Example.framework in Frameworks */,
+				D39460CE1F71D215000396FC /* Split.framework in Frameworks */,
+				63921D5F780CE4DBD840F0D8 /* Pods_Split_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,7 +76,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				087AAC2E222B3A6A92D5DE18 /* Pods_Split_Example_Split_Tests.framework in Frameworks */,
+				D39460CC1F71D09A000396FC /* Nimble.framework in Frameworks */,
+				D39460CD1F71D09A000396FC /* Quick.framework in Frameworks */,
+				6624CA25DEA2C8AE5899C1DC /* Pods_Split_Example_Split_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -144,8 +158,16 @@
 		7BE1D07F8D4AB1835B67B615 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				382E3E34D54A1D485297F610 /* Pods_Split_Example.framework */,
-				E862A556841E8C60069A4B61 /* Pods_Split_Example_Split_Tests.framework */,
+				D39460CA1F71D09A000396FC /* Nimble.framework */,
+				D39460CB1F71D09A000396FC /* Quick.framework */,
+				D39460C61F71CA72000396FC /* Pods_Split_Example.framework */,
+				D39460BD1F71C812000396FC /* Alamofire.framework */,
+				D39460BE1F71C812000396FC /* Nimble.framework */,
+				D39460BF1F71C812000396FC /* Quick.framework */,
+				D39460C01F71C812000396FC /* SwiftyJSON.framework */,
+				D39460BB1F71C7F5000396FC /* Split.framework */,
+				441D254060332D10C49E0F46 /* Pods_Split_Example.framework */,
+				14946A7643C6298E66BB0478 /* Pods_Split_Example_Split_Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Example/Split/Info.plist
+++ b/Example/Split/Info.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+    <key>CALLHOME_URL</key>
+    <string>http://localhost:7548</string>
+    <key>CALLHOME_API_KEY</key>
+    <string>cn57204m9fahk453987nafd</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Split.podspec
+++ b/Split.podspec
@@ -1,5 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
+  s.module_name             = 'Split'
   s.version          = '0.1.0'
   s.summary          = 'iOS SDK for Split'
 
@@ -20,4 +21,21 @@ This SDK is designed to work with Split, the platform for controlled rollouts, s
   s.dependency 'Alamofire', '4.5'
   s.dependency 'SwiftyJSON', '3.1.4'
   s.source_files = 'Split/*.{swift}'
+
+  s.subspec 'Domain' do |ss|
+    ss.source_files = 'Split/Domain/*'
+    ss.source_files = 'Split/Domain/**/*.{swift}'
+  end
+
+  s.subspec 'Extensions' do |ss|
+    ss.source_files = 'Split/Extensions/*'
+  end
+
+  s.subspec 'Infrastructure' do |ss|
+    ss.dependency 'Split/Domain'
+    ss.dependency 'Split/Extensions'
+    ss.source_files = 'Split/Infrastructure/*'
+    ss.source_files = 'Split/Infrastructure/**/*.{swift}'
+  end
+
 end

--- a/Split/Domain/Key.swift
+++ b/Split/Domain/Key.swift
@@ -1,0 +1,31 @@
+//
+//  SplitClient.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 18/9/17.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+@objc public class Key: NSObject {
+    
+    let matchingKey: String
+    let trafficType: String
+    let bucketingKey: String?
+
+    init(matchingKey: String, trafficType: String, bucketingKey: String? = nil) {
+        self.matchingKey = matchingKey
+        self.trafficType = trafficType
+        self.bucketingKey = bucketingKey
+    }
+    
+    func toJSON() -> JSON {
+        var json = JSON(["matchingKey" : self.matchingKey, "trafficType" : self.trafficType])
+        if self.bucketingKey != nil {
+            json["bucketingKey"].stringValue = self.bucketingKey!
+        }
+        return json
+    }
+}

--- a/Split/Domain/Treatment.swift
+++ b/Split/Domain/Treatment.swift
@@ -1,0 +1,26 @@
+//
+//  Split.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 19/9/17.
+//
+//
+
+import Foundation
+import SwiftyJSON
+
+@objc public class Treatment: NSObject {
+    
+    let name: String!
+    let treatment: String!
+    
+    internal init(_ json: JSON) {
+        self.name = json["splitName"].stringValue
+        self.treatment = json["treatment"].stringValue
+    }
+    
+    internal init(_ dict: [String : AnyObject]) {
+        self.name = dict["splitName"]!.stringValue
+        self.treatment = dict["treatment"]!.stringValue
+    }
+}

--- a/Split/Extensions/Dictionary+Extensions.swift
+++ b/Split/Extensions/Dictionary+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  Dictionary+JSON.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 20/9/17.
+//
+//
+
+import Foundation
+
+public func += <K, V> ( left: inout [K : V], right: [K : V]) {
+    for (k, v) in right {
+        left.updateValue(v, forKey: k)
+    }
+}

--- a/Split/Extensions/Dictionary+JSON.swift
+++ b/Split/Extensions/Dictionary+JSON.swift
@@ -1,0 +1,21 @@
+//
+//  Dictionary+JSON.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 20/9/17.
+//
+//
+
+import Foundation
+
+extension Dictionary {
+    
+    func toJSONString() -> String? {
+        let jsonData = try? JSONSerialization.data(withJSONObject: self, options: .init(rawValue: 0))
+        if jsonData != nil {
+            return String(data: jsonData!, encoding: .utf8)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Split/HttpSplitFetcher.swift
+++ b/Split/HttpSplitFetcher.swift
@@ -1,0 +1,34 @@
+//
+//  HttpSplitChangeFetcher.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 19/9/17.
+//
+//
+
+import Foundation
+
+@objc public class HttpSplitFetcher: NSObject, SplitFetcher {
+    
+    private let restClient = RestClient()
+
+    public override init() { }
+    
+    func fetchAll() -> Void {
+        
+    }
+    
+    /**
+     * Forces a sync of splits, outside of any scheduled
+     * syncs. This method MUST NOT throw any exceptions.
+     */
+    public func forceRefresh() -> Void {
+        // TODO: Send real parameters. We need to define where to set and store them to make the interval fetching
+        restClient.getTreatments(keys: [Key(matchingKey: "test", trafficType: "user")], attributes: ["key": "value", "key2": 23]) { result in
+            if let treatments = try? result.unwrap() {
+                // TODO: Persist on local storage
+            }
+        }
+    }
+
+}

--- a/Split/Infrastructure/Network/Configuration/RestClientConfiguration.swift
+++ b/Split/Infrastructure/Network/Configuration/RestClientConfiguration.swift
@@ -1,0 +1,16 @@
+//
+//  RestClientConfiguration.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+struct RestClientConfiguration {
+    static var manager: RestClientManagerProtocol {
+        return SessionManager.default
+    }
+}

--- a/Split/Infrastructure/Network/Endpoints/RestClient+TreatmentEndpoints.swift
+++ b/Split/Infrastructure/Network/Endpoints/RestClient+TreatmentEndpoints.swift
@@ -1,0 +1,23 @@
+//
+//  RestClient+Source.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import SwiftyJSON
+
+extension RestClient {
+    
+    func getTreatments(keys: [Key], attributes: [String : Any]? = nil, completion: @escaping (DataResult<[Treatment]>) -> Void) {
+        self.execute(target: CallhomeTarget.GetTreatments(keys: keys, attributes: attributes), completion: completion) { json in
+            let treatments = json.arrayValue.map { (json: JSON) -> Treatment in
+                let treatment = Treatment(json)
+                return treatment
+            }
+            return treatments
+        }
+    }
+}

--- a/Split/Infrastructure/Network/Errors/ErrorCode.swift
+++ b/Split/Infrastructure/Network/Errors/ErrorCode.swift
@@ -1,0 +1,12 @@
+//
+//  ErrorCode.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+struct ErrorCode {
+    static let Undefined = -9999
+    static let SerializationFailed = 1001
+}

--- a/Split/Infrastructure/Network/Extensions/DataRequest+Extensions.swift
+++ b/Split/Infrastructure/Network/Extensions/DataRequest+Extensions.swift
@@ -1,0 +1,42 @@
+//
+//  ApiProtocol.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+extension DataRequest: RestClientRequestProtocol {
+    
+    static func responseSerializer(errorSanitizer: @escaping (JSON, Int) -> Result<JSON>) -> DataResponseSerializer<JSON> {
+        return DataResponseSerializer<JSON> { request, response, data, error in
+            if let error = error {
+                return .failure(error)
+            }
+            
+            guard let validData = data else {
+                let reason = "Data could not be serialized. Input data was nil."
+                return .failure(NSError(domain: InfoUtils.bundleNameKey(), code: ErrorCode.SerializationFailed, userInfo: [NSLocalizedDescriptionKey : reason]))
+            }
+            
+            let json = JSON(data: validData)
+
+            return errorSanitizer(json, response!.statusCode)
+        }
+    }
+    
+    func getResponse(errorSanitizer: @escaping (JSON, Int) -> Result<JSON>, completionHandler: @escaping (DataResponse<JSON>) -> Void) -> Self {
+        self.validate { request, response, data in
+            return .success
+        }
+        .response(responseSerializer: DataRequest.responseSerializer(errorSanitizer: errorSanitizer)) { response in
+            completionHandler(response)
+        }
+        return self;
+    }
+    
+}

--- a/Split/Infrastructure/Network/Extensions/SessionManager+Extensions.swift
+++ b/Split/Infrastructure/Network/Extensions/SessionManager+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  SessionManagerExtensions.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+extension SessionManager: RestClientManagerProtocol {
+    
+    func sendRequest(target: Target, parameters: [String : AnyObject]? = nil, headers: [String : String]? = nil) -> RestClientRequestProtocol {
+        var httpHeaders = ["Accept" : "application/json"]
+        if let targetSpecificHeaders = target.commonHeaders {
+            httpHeaders += targetSpecificHeaders
+        }
+        if let headers = headers {
+            httpHeaders += headers
+        }
+        
+        return request(target.url, method: target.method, parameters: parameters, encoding: JSONEncoding.default, headers: httpHeaders)
+    }
+}

--- a/Split/Infrastructure/Network/Protocols/RestClientManagerProtocol.swift
+++ b/Split/Infrastructure/Network/Protocols/RestClientManagerProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  ApiManagerProtocol.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+
+protocol RestClientManagerProtocol {
+    func sendRequest(target: Target, parameters: [String : AnyObject]?, headers: [String : String]?) -> RestClientRequestProtocol
+}
+
+extension RestClientManagerProtocol {
+    func sendRequest(target: Target, parameters: [String : AnyObject]? = nil) -> RestClientRequestProtocol {
+        return sendRequest(target: target, parameters: parameters, headers: nil)
+    }
+}

--- a/Split/Infrastructure/Network/Protocols/RestClientRequestProtocol.swift
+++ b/Split/Infrastructure/Network/Protocols/RestClientRequestProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  ApiRequestProtocol.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+protocol RestClientRequestProtocol {
+    func getResponse(errorSanitizer: @escaping (JSON, Int) -> Result<JSON>, completionHandler: @escaping (DataResponse<JSON>) -> Void) -> Self
+}

--- a/Split/Infrastructure/Network/RestClient.swift
+++ b/Split/Infrastructure/Network/RestClient.swift
@@ -1,0 +1,47 @@
+//
+//  Api.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+final class RestClient {
+    // MARK: - Private Properties
+    private let manager: RestClientManagerProtocol
+    
+    // MARK: - Designated Initializer
+    init(manager: RestClientManagerProtocol = RestClientConfiguration.manager) {
+        self.manager = manager
+    }
+    
+    // MARK: - Private Functions
+    private func start<T: Any>(target: Target, completion: @escaping (DataResult<T>) -> Void, processResponse: @escaping (JSON) -> Any?) {
+        let _ = manager.sendRequest(target: target).getResponse(errorSanitizer: target.errorSanitizer) { response in
+            switch response.result {
+            case .success(let json):
+                let parsedObject = processResponse(json) as! T
+                completion( DataResult{ return parsedObject } )
+            case .failure(let error):
+                completion( DataResult{ throw error })
+            }
+        }
+    }
+    
+    // MARK: - Internal Functions
+    internal func execute(target: Target, completion: @escaping (DataResult<Void>) -> Void, processResponse: @escaping (JSON) -> Void) {
+        self.start(target: target, completion: completion, processResponse: processResponse)
+    }
+    
+    internal func execute<T: AnyObject>(target: Target, completion: @escaping (DataResult<T>) -> Void, processResponse: @escaping (JSON) -> T?) {
+        self.start(target: target, completion: completion, processResponse: processResponse)
+    }
+    
+    internal func execute<T: AnyObject>(target: Target, completion: @escaping (DataResult<[T]>) -> Void, processResponse: @escaping (JSON) -> [T]?) {
+        self.start(target: target, completion: completion, processResponse: processResponse)
+    }
+}

--- a/Split/Infrastructure/Network/Results/DataResult.swift
+++ b/Split/Infrastructure/Network/Results/DataResult.swift
@@ -1,0 +1,32 @@
+//
+//  DataResult.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+
+enum DataResult<Value> {
+    case Success(value: Value)
+    case Failure(error: NSError)
+    
+    init(_ f: () throws -> Value) {
+        do {
+            let value = try f()
+            self = .Success(value: value)
+        } catch let error as NSError {
+            self = .Failure(error: error)
+        }
+    }
+    
+    func unwrap() throws -> Value {
+        switch self {
+        case .Success(let value):
+            return value
+        case .Failure(let error):
+            throw error
+        }
+    }
+}

--- a/Split/Infrastructure/Network/Targets/CallhomeTarget.swift
+++ b/Split/Infrastructure/Network/Targets/CallhomeTarget.swift
@@ -1,0 +1,49 @@
+//
+//  NewsApiEndpoint.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+enum CallhomeTarget: Target {
+    
+    var baseUrl: URL { return URL(string: InfoUtils.valueForKey(key: "CALLHOME_URL"))! }
+    var apiKey: String? { return InfoUtils.valueForKey(key: "CALLHOME_API_KEY") }
+    // Insert your common headers here, for example, authorization token or accept.
+    var commonHeaders: [String : String]? { return ["Authorization" : "Bearer \(apiKey!)"] }
+    
+    case GetTreatments(keys: [Key], attributes: [String : Any]?)
+    
+    // MARK: - Public Properties
+    var method: HTTPMethod {
+        switch self {
+            case .GetTreatments:
+                return .get
+        }
+    }
+    
+    var url: URL {
+        switch self {
+            case .GetTreatments(let keys, let attributes):
+                let url = baseUrl.appendingPathComponent("get-treatments")
+                let keysJSON = keys.map { $0.toJSON() }
+                let params = "?keys=\(JSON(keysJSON).rawString(options:JSONSerialization.WritingOptions(rawValue: 0))!)&attributes=\(attributes != nil ? attributes!.toJSONString()! : "")"
+                return URL(string: params.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!, relativeTo: url)!
+        }
+    }
+    
+    var errorSanitizer: (JSON, Int) -> Result<JSON> {
+        return { json, statusCode in
+            guard statusCode >= 200 && statusCode <= 203 else {
+                let error = NSError(domain: InfoUtils.bundleNameKey(), code: ErrorCode.Undefined, userInfo: nil)
+                return .failure(error)
+            }
+            return .success(json)
+        }
+    }
+}

--- a/Split/Infrastructure/Network/Targets/Target.swift
+++ b/Split/Infrastructure/Network/Targets/Target.swift
@@ -1,0 +1,20 @@
+//
+//  Endpoint.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 9/19/17.
+//  Copyright © 2017 Split Software. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import SwiftyJSON
+
+protocol Target {
+    var baseUrl: URL { get }
+    var apiKey: String? { get }
+    var commonHeaders: [String : String]? { get }
+    var method: HTTPMethod { get }
+    var url: URL { get }
+    var errorSanitizer: (JSON, Int) -> Result<JSON> { get }
+}

--- a/Split/Infrastructure/Utils/InfoUtils.swift
+++ b/Split/Infrastructure/Utils/InfoUtils.swift
@@ -1,0 +1,28 @@
+//
+//  InfoUtils.swift
+//  SwiftSeedProject
+//
+//  Created by Brian Sztamfater on 21/4/17.
+//  Copyright © 2017 Making Sense. All rights reserved.
+//
+
+import Foundation
+
+class InfoUtils {
+    
+    static func bundleNameKey() -> String {
+        guard let info = Bundle.main.infoDictionary,
+            let domain = info[kCFBundleNameKey as String] as? String else {
+                fatalError("Cannot get bundle name key from Info.plist")
+        }
+        return domain;
+    }
+    
+    static func valueForKey(key: String) -> String {
+        guard let info = Bundle.main.infoDictionary,
+            let domain = info[key] as? String else {
+                fatalError("Cannot get \(key) key from Info.plist")
+        }
+        return domain;
+    }
+}

--- a/Split/SplitFetcher.swift
+++ b/Split/SplitFetcher.swift
@@ -1,0 +1,20 @@
+//
+//  SplitChangeFetcher.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 19/9/17.
+//
+//
+
+import Foundation
+
+@objc protocol SplitFetcher {
+    
+    func fetchAll() -> Void
+    
+    /**
+     * Forces a sync of splits, outside of any scheduled
+     * syncs. This method MUST NOT throw any exceptions.
+     */
+    func forceRefresh() -> Void
+}


### PR DESCRIPTION
## Background

We need to add the networking layer to communicate with a Callhome instance

## Changes done

- Added a networking layer with Alamofire
- Added Key and Treatment domain classes to implement `/get-treatments` endpoint
- Implemented `/get-treatments` endpoint
- Added some Util classes to get Info.plist values
- Defined some keys for the Info.plist so developers can define their custom URL and API Key for the Callhome instance
- Added a HttpSplitFetcher to test `/get-treatments` endpoint
- Fixed Podfile to load Split framework on the Example project

## Result

![splitfetch](https://user-images.githubusercontent.com/18485527/30652714-75b89312-9dff-11e7-937b-a803e4e06c9f.gif)

## Reviewers required

@patricioe @sarrubia 