### PR TITLE
Implement blockUntilReady functionality

### DIFF
--- a/Example/Split/ViewController.swift
+++ b/Example/Split/ViewController.swift
@@ -14,9 +14,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-        let config = SplitClientConfig(pollForFeatureChangesInterval: 5)
+        let config = SplitClientConfig(pollForFeatureChangesInterval: 5, blockUntilReady: 5000)
         let trafficType = TrafficType(matchingKey: "test", type: "user")
-        SplitClient.shared.initialize(withConfig: config, andTrafficType: trafficType)
+        try? SplitClient.shared.initialize(withConfig: config, andTrafficType: trafficType)
         
         debugPrint(SplitClient.shared.getTreatment(forSplit: "Test"))
         debugPrint(SplitClient.shared.getTreatment(forSplit: "Test2"))

--- a/Split/Infrastructure/Network/Extensions/DataRequest+Extensions.swift
+++ b/Split/Infrastructure/Network/Extensions/DataRequest+Extensions.swift
@@ -33,7 +33,7 @@ extension DataRequest: RestClientRequestProtocol {
         self.validate { request, response, data in
             return .success
         }
-        .response(responseSerializer: DataRequest.responseSerializer(errorSanitizer: errorSanitizer)) { response in
+        .response(queue: DispatchQueue(label: "split-rest-queue"), responseSerializer: DataRequest.responseSerializer(errorSanitizer: errorSanitizer)) { response in
             completionHandler(response)
         }
         return self;

--- a/Split/SplitClient+Features.swift
+++ b/Split/SplitClient+Features.swift
@@ -11,7 +11,7 @@ import Foundation
 extension SplitClient {
     
     func startPollingForFeatures() {
-        let queue = DispatchQueue.main
+        let queue = DispatchQueue(label: "split-timer-queue")
         featurePollTimer = DispatchSource.makeTimerSource(queue: queue)
         featurePollTimer!.scheduleRepeating(deadline: .now(), interval: .seconds(self.config!.pollForFeatureChangesInterval))
         featurePollTimer!.setEventHandler { [weak self] in
@@ -40,6 +40,10 @@ extension SplitClient {
             let dict = NSMutableDictionary()
             treatments.forEach { dict.setObject($0.treatment, forKey: $0.name as NSString) }
             strongSelf.persistence.saveAll(dict as! [String : String])
+            if let semaphore = strongSelf.semaphore {
+                semaphore.signal()
+                strongSelf.semaphore = nil
+            }
         }
     }
     

--- a/Split/SplitClientConfig.swift
+++ b/Split/SplitClientConfig.swift
@@ -15,14 +15,16 @@ import Foundation
     var impressionsQueueSize: Int
     var connectionTimeout: Int
     var debugEnabled: Bool
+    var blockUntilReady: Int
     
     // TODO: Add pending parameters
-    public init(pollForFeatureChangesInterval: Int? = 30, impressionsRefreshRate: Int? = 30, impressionsQueueSize: Int? = 30000, connectionTimeout: Int? = 15000, debugEnabled: Bool? = false) {
+    public init(pollForFeatureChangesInterval: Int? = 30, impressionsRefreshRate: Int? = 30, impressionsQueueSize: Int? = 30000, connectionTimeout: Int? = 15000, debugEnabled: Bool? = false, blockUntilReady: Int? = -1) {
         self.pollForFeatureChangesInterval = pollForFeatureChangesInterval!
         self.impressionsRefreshRate = impressionsRefreshRate!
         self.impressionsQueueSize = impressionsQueueSize!
         self.connectionTimeout = connectionTimeout!
         self.debugEnabled = debugEnabled!
+        self.blockUntilReady = blockUntilReady!
     }
     
 }

--- a/Split/SplitClientProtocol.swift
+++ b/Split/SplitClientProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @objc public protocol SplitClientProtocol {
     
-    func initialize(withConfig config: SplitClientConfig, andTrafficType trafficType: TrafficType)
+    func initialize(withConfig config: SplitClientConfig, andTrafficType trafficType: TrafficType) throws
 
     func getTreatment(forSplit split: String) -> String
     

--- a/Split/SplitError.swift
+++ b/Split/SplitError.swift
@@ -1,0 +1,13 @@
+//
+//  SplitError.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 25/9/17.
+//
+//
+
+import Foundation
+
+enum SplitError: Error {
+    case timeout(reason: String)
+}


### PR DESCRIPTION
## Background

We need to support blockUntilReady functionality

## Changes done

- Added blockUntilReady parameter on SplitClientConfig with a default of -1
- Added a semaphore variable on SplitClient and initialize it if blockUntilReady value is greater than -1
- If that is the case, call .wait on the semaphore object with a timeout of now() + blockUntilReady
- Signal semaphore when client is ready
- Throw a timeout error is semaphore timeouts

## Reviewers required

@patricioe @sarrubia 