### PR TITLE
Refactor SplitClient creation with SplitFactory

### DIFF
--- a/Example/Split/ViewController.swift
+++ b/Example/Split/ViewController.swift
@@ -13,15 +13,17 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+
         let config = SplitClientConfig(pollForFeatureChangesInterval: 5, blockUntilReady: 5000)
-        let trafficType = TrafficType(matchingKey: "test", type: "user")
-        try? SplitClient.shared.initialize(withConfig: config, andTrafficType: trafficType)
+        guard let splitFactory = try? SplitFactory(apiToken: "", config: config) else {
+            return
+        }
+        let client = splitFactory.splitClient()
         
-        debugPrint(SplitClient.shared.getTreatment(forSplit: "Test"))
-        debugPrint(SplitClient.shared.getTreatment(forSplit: "Test2"))
-        debugPrint(SplitClient.shared.getTreatment(forSplit: "fsdfsdf"))
-        debugPrint(SplitClient.shared.getTreatment(forSplit: "test-net"))
+        debugPrint(client.getTreatment(forSplit: "Test"))
+        debugPrint(client.getTreatment(forSplit: "Test2"))
+        debugPrint(client.getTreatment(forSplit: "fsdfsdf"))
+        debugPrint(client.getTreatment(forSplit: "test-net"))
     }
 
     override func didReceiveMemoryWarning() {

--- a/Example/Split/ViewController.swift
+++ b/Example/Split/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
         guard let splitFactory = try? SplitFactory(apiToken: "", config: config) else {
             return
         }
-        let client = splitFactory.splitClient()
+        let client = splitFactory.client()
         
         debugPrint(client.getTreatment(forSplit: "Test"))
         debugPrint(client.getTreatment(forSplit: "Test2"))

--- a/Split.podspec
+++ b/Split.podspec
@@ -20,7 +20,8 @@ This SDK is designed to work with Split, the platform for controlled rollouts, s
   s.frameworks = 'Foundation'
   s.dependency 'Alamofire', '4.5'
   s.dependency 'SwiftyJSON', '3.1.4'
-  s.source_files = 'Split/*.{swift}'
+s.source_files = 'Split/*.{swift}'
+s.source_files = 'Split/**/*.{swift}'
 
   s.subspec 'Domain' do |ss|
     ss.source_files = 'Split/Domain/*'

--- a/Split/Api/SplitView.swift
+++ b/Split/Api/SplitView.swift
@@ -1,0 +1,19 @@
+//
+//  SplitView.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 27/9/17.
+//
+//
+
+import Foundation
+
+@objc public class SplitView: NSObject {
+    
+    public var name: String?
+    public var trafficType: String?
+    public var killed: Bool?
+    public var treatments: [String]?
+    public var changeNumber: Int64?
+    
+}

--- a/Split/SplitClient+Features.swift
+++ b/Split/SplitClient+Features.swift
@@ -13,12 +13,12 @@ extension SplitClient {
     func startPollingForFeatures() {
         let queue = DispatchQueue(label: "split-timer-queue")
         featurePollTimer = DispatchSource.makeTimerSource(queue: queue)
-        featurePollTimer!.scheduleRepeating(deadline: .now(), interval: .seconds(self.config!.pollForFeatureChangesInterval))
+        featurePollTimer!.scheduleRepeating(deadline: .now(), interval: .seconds(self.config.pollForFeatureChangesInterval))
         featurePollTimer!.setEventHandler { [weak self] in
             guard let strongSelf = self else {
                 return
             }
-            guard strongSelf.initialized else {
+            guard strongSelf.initialized! else {
                 strongSelf.stopPollingForFeatures()
                 return
             }
@@ -33,7 +33,7 @@ extension SplitClient {
     }
     
     func pollForFeatures() {
-        fetcher.fetchAll(keys: [self.trafficType!.key], attributes: self.trafficType!.attributes) { [weak self] treatments in
+        fetcher.fetchAll(keys: [Key(matchingKey: "test", trafficType: "user")], attributes: [:]) { [weak self] treatments in
             guard let strongSelf = self else {
                 return
             }

--- a/Split/SplitClientProtocol.swift
+++ b/Split/SplitClientProtocol.swift
@@ -10,8 +10,6 @@ import Foundation
 
 @objc public protocol SplitClientProtocol {
     
-    func initialize(withConfig config: SplitClientConfig, andTrafficType trafficType: TrafficType) throws
-
     func getTreatment(forSplit split: String) -> String
     
 }

--- a/Split/SplitError.swift
+++ b/Split/SplitError.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-enum SplitError: Error {
-    case timeout(reason: String)
+@objc public enum SplitError: Int, Error {
+    case Timeout
 }

--- a/Split/SplitFactory.swift
+++ b/Split/SplitFactory.swift
@@ -10,22 +10,22 @@ import Foundation
 
 @objc public class SplitFactory: NSObject, SplitFactoryProtocol {
     
-    let _splitClient: SplitClientProtocol
-    let _splitManager: SplitManagerProtocol
+    let _client: SplitClientProtocol
+    let _manager: SplitManagerProtocol
     
     public init(apiToken: String, config: SplitClientConfig) throws {
         // TODO: Use apiKey, review and refactor client parameters
         let splitClient = try SplitClient(fetcher: HttpSplitFetcher(), persistence: PlistSplitPersistence(fileName: "splits"), config: config)
-        _splitClient = splitClient
-        _splitManager = SplitManager()
+        _client = splitClient
+        _manager = SplitManager()
     }
 
-    public func splitClient() -> SplitClientProtocol {
-        return _splitClient
+    public func client() -> SplitClientProtocol {
+        return _client
     }
     
-    public func splitManager() -> SplitManagerProtocol {
-        return _splitManager
+    public func manager() -> SplitManagerProtocol {
+        return _manager
     }
     
 }

--- a/Split/SplitFactory.swift
+++ b/Split/SplitFactory.swift
@@ -1,0 +1,31 @@
+//
+//  SplitFactory.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 27/9/17.
+//
+//
+
+import Foundation
+
+@objc public class SplitFactory: NSObject, SplitFactoryProtocol {
+    
+    let _splitClient: SplitClientProtocol
+    let _splitManager: SplitManagerProtocol
+    
+    public init(apiToken: String, config: SplitClientConfig) throws {
+        // TODO: Use apiKey, review and refactor client parameters
+        let splitClient = try SplitClient(fetcher: HttpSplitFetcher(), persistence: PlistSplitPersistence(fileName: "splits"), config: config)
+        _splitClient = splitClient
+        _splitManager = SplitManager()
+    }
+
+    public func splitClient() -> SplitClientProtocol {
+        return _splitClient
+    }
+    
+    public func splitManager() -> SplitManagerProtocol {
+        return _splitManager
+    }
+    
+}

--- a/Split/SplitFactoryProtocol.swift
+++ b/Split/SplitFactoryProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  SplitFactoryProtocol.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 27/9/17.
+//
+//
+
+import Foundation
+
+@objc public protocol SplitFactoryProtocol {
+    
+    func splitClient() -> SplitClientProtocol
+    
+    func splitManager() -> SplitManagerProtocol
+    
+}

--- a/Split/SplitFactoryProtocol.swift
+++ b/Split/SplitFactoryProtocol.swift
@@ -10,8 +10,8 @@ import Foundation
 
 @objc public protocol SplitFactoryProtocol {
     
-    func splitClient() -> SplitClientProtocol
+    func client() -> SplitClientProtocol
     
-    func splitManager() -> SplitManagerProtocol
+    func manager() -> SplitManagerProtocol
     
 }

--- a/Split/SplitManager.swift
+++ b/Split/SplitManager.swift
@@ -1,0 +1,26 @@
+//
+//  SplitManager.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 27/9/17.
+//
+//
+
+import Foundation
+
+@objc public class SplitManager: NSObject, SplitManagerProtocol {
+    
+    public override init() { }
+    
+    public func splits() -> [SplitView] {
+        return []
+    }
+    
+    public func split(featureName: String) -> SplitView {
+        return SplitView()
+    }
+    
+    public func splitNames() -> [String] {
+        return []
+    }
+}

--- a/Split/SplitManagerProtocol.swift
+++ b/Split/SplitManagerProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  SplitManagerProtocol.swift
+//  Pods
+//
+//  Created by Brian Sztamfater on 27/9/17.
+//
+//
+
+import Foundation
+
+@objc public protocol SplitManagerProtocol {
+    
+    func splits() -> [SplitView]
+    
+    func split(featureName: String) -> SplitView
+    
+    func splitNames() -> [String]
+
+}


### PR DESCRIPTION
## Background

We need to add SplitFactory to be consistent with other SDKs

## Changes done

- Added SplitFactoryProtocol and SplitFactory
- Added SplitManagerProtocol and SplitManager
- Added SplitView
- Refactored SplitClient so SplitFactory can create a SplitClient and throw errors
- Modified SplitError enum to be compatible with Objective-C
- Modified example code to show how to instantiate a new SplitClient

## Reviewers required

@patricioe @sarrubia 