### PR TITLE
SDKS-1605: Clear old splits cache

### DIFF
--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		31AA2DCDCA8E9F63F47F7D29 /* SplitEventsManagerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AA279035168CE07F14D769 /* SplitEventsManagerStub.swift */; };
 		3B6DEF0C20EA6AE50067435E /* InMemoryMySegmentsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE6720EA6ADF0067435E /* InMemoryMySegmentsCache.swift */; };
 		3B6DEF0D20EA6AE50067435E /* InMemorySplitCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE6820EA6ADF0067435E /* InMemorySplitCache.swift */; };
 		3B6DEF0E20EA6AE50067435E /* MySegmentsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE6920EA6ADF0067435E /* MySegmentsCache.swift */; };
@@ -239,6 +240,8 @@
 		599EDAF12270970500D7DACB /* SplitEventsManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599EDAF02270970500D7DACB /* SplitEventsManagerMock.swift */; };
 		599EDAF32270A15B00D7DACB /* localhost.splits in Resources */ = {isa = PBXBuildFile; fileRef = 599EDAF22270A15B00D7DACB /* localhost.splits */; };
 		599EDAF52270AD6700D7DACB /* wrong_format.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 599EDAF42270AD6700D7DACB /* wrong_format.yaml */; };
+		59AD7AC32461D36400F5B0B4 /* RefreshableSplitFetcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD7AC22461D36400F5B0B4 /* RefreshableSplitFetcherTest.swift */; };
+		59AD7AC52461D63500F5B0B4 /* SplitChangeFetcherStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD7AC42461D63500F5B0B4 /* SplitChangeFetcherStub.swift */; };
 		59AD7FD322F38BEF00F569C3 /* TrackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD7FD222F38BEF00F569C3 /* TrackManager.swift */; };
 		59B8B8AA220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B8B8A9220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift */; };
 		59B8B8AC220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B8B8AB220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift */; };
@@ -318,6 +321,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		31AA279035168CE07F14D769 /* SplitEventsManagerStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplitEventsManagerStub.swift; sourceTree = "<group>"; };
 		3B6DEE5A20EA6A4E0067435E /* Split.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Split.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B6DEE5E20EA6A4E0067435E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3B6DEE6720EA6ADF0067435E /* InMemoryMySegmentsCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryMySegmentsCache.swift; sourceTree = "<group>"; };
@@ -554,6 +558,8 @@
 		599EDAF02270970500D7DACB /* SplitEventsManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitEventsManagerMock.swift; sourceTree = "<group>"; };
 		599EDAF22270A15B00D7DACB /* localhost.splits */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = localhost.splits; sourceTree = "<group>"; };
 		599EDAF42270AD6700D7DACB /* wrong_format.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wrong_format.yaml; sourceTree = "<group>"; };
+		59AD7AC22461D36400F5B0B4 /* RefreshableSplitFetcherTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableSplitFetcherTest.swift; sourceTree = "<group>"; };
+		59AD7AC42461D63500F5B0B4 /* SplitChangeFetcherStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitChangeFetcherStub.swift; sourceTree = "<group>"; };
 		59AD7FD222F38BEF00F569C3 /* TrackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackManager.swift; sourceTree = "<group>"; };
 		59B8B8A9220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SyncDictionaryCollectionWrapperTest.swift; path = SplitTests/SyncDictionaryCollectionWrapperTest.swift; sourceTree = SOURCE_ROOT; };
 		59B8B8AB220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncDictionarySingleWrapperTest.swift; sourceTree = "<group>"; };
@@ -1093,6 +1099,8 @@
 				5959C47F228051CA0064F968 /* SplitManagerStub.swift */,
 				5959C481228074800064F968 /* ValidationMessageLoggerStub.swift */,
 				594677E922D4D44300F94E58 /* ImpressionsManagerStub.swift */,
+				59AD7AC42461D63500F5B0B4 /* SplitChangeFetcherStub.swift */,
+				31AA279035168CE07F14D769 /* SplitEventsManagerStub.swift */,
 			);
 			path = Fake;
 			sourceTree = "<group>";
@@ -1160,6 +1168,7 @@
 				599A6E2C22F8C65500D3D68C /* ImpressionsManagerTest.swift */,
 				594677E322CFF30B00F94E58 /* TreatmentManagerTest.swift */,
 				59BF90B8239A75520007A896 /* VersionTest.swift */,
+				59AD7AC22461D36400F5B0B4 /* RefreshableSplitFetcherTest.swift */,
 			);
 			path = SplitTests;
 			sourceTree = "<group>";
@@ -1723,6 +1732,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				597CD33C216D042300A15487 /* MetricsRestClientStub.swift in Sources */,
+				59AD7AC32461D36400F5B0B4 /* RefreshableSplitFetcherTest.swift in Sources */,
 				5959C47E228051040064F968 /* SplitClientStub.swift in Sources */,
 				59D84BE3221734F5003DA248 /* LocalhostSplitClientTests.swift in Sources */,
 				592C6AC6211B718E002D120C /* SplitEventsManagerTest.swift in Sources */,
@@ -1787,6 +1797,7 @@
 				596A7B622343F848004F6139 /* MySegmentUpadatedTest.swift in Sources */,
 				5982D938219F57BE00230F44 /* FileHelper.swift in Sources */,
 				594677EA22D4D44300F94E58 /* ImpressionsManagerStub.swift in Sources */,
+				59AD7AC52461D63500F5B0B4 /* SplitChangeFetcherStub.swift in Sources */,
 				59BF90B9239A75520007A896 /* VersionTest.swift in Sources */,
 				595B66CD231D91100030F330 /* SplitChangesTest.swift in Sources */,
 				5959C47C228050750064F968 /* SplitFactoryStub.swift in Sources */,
@@ -1794,6 +1805,7 @@
 				59FB7C1A21F7ACF300ECC96A /* SplitValidatorTests.swift in Sources */,
 				597848BB21BB072B00ABB4A6 /* SplitCacheTests.swift in Sources */,
 				593AE9FF226F5B98000D61B0 /* SplitChangeFetcherTests.swift in Sources */,
+				31AA2DCDCA8E9F63F47F7D29 /* SplitEventsManagerStub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Split/Api/DefaultSplitFactory.swift
+++ b/Split/Api/DefaultSplitFactory.swift
@@ -56,7 +56,7 @@ public class DefaultSplitFactory: NSObject, SplitFactory {
 
         let refreshableSplitFetcher = DefaultRefreshableSplitFetcher(
             splitChangeFetcher: httpSplitFetcher, splitCache: splitCache, interval: config.featuresRefreshRate,
-            eventsManager: eventsManager)
+            cacheExpiration: config.cacheExpirationInSeconds, eventsManager: eventsManager)
 
         let mySegmentsFetcher = HttpMySegmentsFetcher(restClient: RestClient(), mySegmentsCache: mySegmentsCache)
         let refreshableMySegmentsFetcher = DefaultRefreshableMySegmentsFetcher(

--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -190,6 +190,6 @@ public class SplitClientConfig: NSObject {
     ///
     /// Time to consider that cache has expired
     ///
-    let cacheExpirationInSeconds = 30//864000
+    let cacheExpirationInSeconds = 864000
 
 }

--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -190,6 +190,6 @@ public class SplitClientConfig: NSObject {
     ///
     /// Time to consider that cache has expired
     ///
-    let cacheExpirationInSeconds = 864000
+    let cacheExpirationInSeconds = 30//864000
 
 }

--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -187,4 +187,9 @@ public class SplitClientConfig: NSObject {
     ///
     let initialEventSizeInBytes = 1024
 
+    ///
+    /// Time to consider that cache has expired
+    ///
+    let cacheExpirationInSeconds = 864000
+
 }

--- a/Split/FetcherEngine/Cache/InMemorySplitCache.swift
+++ b/Split/FetcherEngine/Cache/InMemorySplitCache.swift
@@ -17,10 +17,11 @@ class InMemorySplitCache: NSObject, SplitCacheProtocol {
     private var trafficTypes = [String: Int]()
     private var timestamp: Int = 0
 
-    init(splits: [String: Split] = [:], changeNumber: Int64 = -1) {
+    init(splits: [String: Split] = [:], changeNumber: Int64 = -1, timestamp: Int? = 0) {
         self.queue = DispatchQueue(label: queueName, attributes: .concurrent)
         self.splits = [:]
         self.changeNumber = changeNumber
+        self.timestamp = timestamp ?? 0
         super.init()
         initSplits(splits: splits)
     }
@@ -86,6 +87,10 @@ class InMemorySplitCache: NSObject, SplitCacheProtocol {
 
     func getTimestamp() -> Int {
         return timestamp
+    }
+
+    func setTimestamp(timestamp: Int) {
+        self.timestamp = timestamp
     }
 }
 

--- a/Split/FetcherEngine/Cache/InMemorySplitCache.swift
+++ b/Split/FetcherEngine/Cache/InMemorySplitCache.swift
@@ -87,10 +87,6 @@ class InMemorySplitCache: NSObject, SplitCacheProtocol {
     func getTimestamp() -> Int {
         return timestamp
     }
-
-    func updateTimestamp() {
-        timestamp = Int(Date().timeIntervalSince1970)
-    }
 }
 
 extension InMemorySplitCache {

--- a/Split/FetcherEngine/Cache/InMemorySplitCache.swift
+++ b/Split/FetcherEngine/Cache/InMemorySplitCache.swift
@@ -15,6 +15,7 @@ class InMemorySplitCache: NSObject, SplitCacheProtocol {
     private var splits: [String: Split]
     private var changeNumber: Int64
     private var trafficTypes = [String: Int]()
+    private var timestamp: Int = 0
 
     init(splits: [String: Split] = [:], changeNumber: Int64 = -1) {
         self.queue = DispatchQueue(label: queueName, attributes: .concurrent)
@@ -81,6 +82,14 @@ class InMemorySplitCache: NSObject, SplitCacheProtocol {
             exists = (self.trafficTypes[trafficType.lowercased()] != nil)
         }
         return exists
+    }
+
+    func getTimestamp() -> Int {
+        return timestamp
+    }
+
+    func updateTimestamp() {
+        timestamp = Int(Date().timeIntervalSince1970)
     }
 }
 

--- a/Split/FetcherEngine/Cache/SplitCache.swift
+++ b/Split/FetcherEngine/Cache/SplitCache.swift
@@ -67,6 +67,9 @@ class SplitCache: SplitCacheProtocol {
     }
 
     func clear() {
+        inMemoryCache.clear()
+        inMemoryCache.setChangeNumber(-1)
+        fileStorage.delete(fileName: kSplitsFileName)
     }
 }
 

--- a/Split/FetcherEngine/Cache/SplitCache.swift
+++ b/Split/FetcherEngine/Cache/SplitCache.swift
@@ -19,11 +19,12 @@ class SplitCache: SplitCacheProtocol {
     private struct SplitsFile: Codable {
         var splits: [String: Split]
         var changeNumber: Int64
+        var timestamp: Int = 0
     }
 
     let kSplitsFileName: String = "SPLITIO.splits"
-    let fileStorage: FileStorageProtocol
-    var inMemoryCache: InMemorySplitCache!
+    private let fileStorage: FileStorageProtocol
+    private var inMemoryCache: InMemorySplitCache!
 
     init(fileStorage: FileStorageProtocol) {
         self.fileStorage = fileStorage
@@ -71,6 +72,14 @@ class SplitCache: SplitCacheProtocol {
         inMemoryCache.setChangeNumber(-1)
         fileStorage.delete(fileName: kSplitsFileName)
     }
+
+    func getTimestamp() -> Int {
+        return inMemoryCache.getTimestamp()
+    }
+
+    func updateTimestamp() {
+        inMemoryCache.updateTimestamp()
+    }
 }
 
 // MARK: Private
@@ -93,7 +102,7 @@ extension SplitCache {
     }
 
     private func saveSplits() {
-        let splitsFile = SplitsFile(splits: getSplits(), changeNumber: getChangeNumber())
+        let splitsFile = SplitsFile(splits: getSplits(), changeNumber: getChangeNumber(), timestamp: getTimestamp())
         do {
             let jsonSplits = try Json.encodeToJson(splitsFile)
             fileStorage.write(fileName: kSplitsFileName, content: jsonSplits)

--- a/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
@@ -18,4 +18,5 @@ protocol SplitCacheProtocol {
     func exists(trafficType: String) -> Bool
     func clear()
     func getTimestamp() -> Int
+    func setTimestamp(timestamp: Int)
 }

--- a/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
@@ -17,4 +17,6 @@ protocol SplitCacheProtocol {
     func getAllSplits() -> [Split]
     func exists(trafficType: String) -> Bool
     func clear()
+    func getTimestamp() -> Int
+    func updateTimestamp()
 }

--- a/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
@@ -18,5 +18,4 @@ protocol SplitCacheProtocol {
     func exists(trafficType: String) -> Bool
     func clear()
     func getTimestamp() -> Int
-    func updateTimestamp()
 }

--- a/Split/FetcherEngine/Cache/SplitChangeCache.swift
+++ b/Split/FetcherEngine/Cache/SplitChangeCache.swift
@@ -26,7 +26,6 @@ class  SplitChangeCache: SplitChangeCacheProtocol {
             for split in splitChange.splits! {
                 _ = self.splitCache?.addSplit(splitName: split.name!, split: split)
             }
-            self.splitCache?.updateTimestamp()
         }
         return true
     }

--- a/Split/FetcherEngine/Cache/SplitChangeCache.swift
+++ b/Split/FetcherEngine/Cache/SplitChangeCache.swift
@@ -26,6 +26,7 @@ class  SplitChangeCache: SplitChangeCacheProtocol {
             for split in splitChange.splits! {
                 _ = self.splitCache?.addSplit(splitName: split.name!, split: split)
             }
+            self.splitCache?.updateTimestamp()
         }
         return true
     }

--- a/Split/FetcherEngine/Cache/SplitChangeCache.swift
+++ b/Split/FetcherEngine/Cache/SplitChangeCache.swift
@@ -26,6 +26,7 @@ class  SplitChangeCache: SplitChangeCacheProtocol {
             for split in splitChange.splits! {
                 _ = self.splitCache?.addSplit(splitName: split.name!, split: split)
             }
+            self.splitCache?.setTimestamp(timestamp: Int(Date().timeIntervalSince1970))
         }
         return true
     }

--- a/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
+++ b/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
@@ -99,12 +99,15 @@ class DefaultRefreshableSplitFetcher: RefreshableSplitFetcher {
                 return
             }
             do {
-                let timestamp = strongSelf.splitCache.getTimestamp()
+
                 var changeNumber = strongSelf.splitCache.getChangeNumber()
-                let elapsedTime = Int(Date().timeIntervalSince1970) - timestamp
-                if changeNumber != -1 && elapsedTime > strongSelf.cacheExpiration {
-                    changeNumber = -1
-                    strongSelf.splitCache.clear()
+                if changeNumber != -1 {
+                    let timestamp = strongSelf.splitCache.getTimestamp()
+                    let elapsedTime = Int(Date().timeIntervalSince1970) - timestamp
+                    if elapsedTime > strongSelf.cacheExpiration {
+                        changeNumber = -1
+                        strongSelf.splitCache.clear()
+                    }
                 }
                 let splitChanges =
                     try strongSelf.splitChangeFetcher.fetch(since: changeNumber)

--- a/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
+++ b/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
@@ -33,7 +33,7 @@ class DefaultRefreshableSplitFetcher: RefreshableSplitFetcher {
         self.interval = interval
         self.dispatchGroup = dispatchGroup
         self.eventsManager = eventsManager
-        self.cacheExpiration = cacheExpiration;
+        self.cacheExpiration = cacheExpiration
     }
 
     func forceRefresh() {
@@ -99,15 +99,15 @@ class DefaultRefreshableSplitFetcher: RefreshableSplitFetcher {
                 return
             }
             do {
-                var storedChangeNumber = strongSelf.splitCache.getChangeNumber()
-                let elapsedTime = (Date().unixTimestampInMiliseconds()
-                    - storedChangeNumber) / 1000
-                if storedChangeNumber != -1 && elapsedTime > strongSelf.cacheExpiration {
-                    storedChangeNumber = -1
+                let timestamp = strongSelf.splitCache.getTimestamp()
+                var changeNumber = strongSelf.splitCache.getChangeNumber()
+                let elapsedTime = Int(Date().timeIntervalSince1970) - timestamp
+                if changeNumber != -1 && elapsedTime > strongSelf.cacheExpiration {
+                    changeNumber = -1
                     strongSelf.splitCache.clear()
                 }
                 let splitChanges =
-                    try strongSelf.splitChangeFetcher.fetch(since: storedChangeNumber)
+                    try strongSelf.splitChangeFetcher.fetch(since: changeNumber)
                 Logger.d(splitChanges.debugDescription)
 
                 strongSelf.dispatchGroup?.leave()

--- a/SplitTests/Fake/SplitCacheStub.swift
+++ b/SplitTests/Fake/SplitCacheStub.swift
@@ -16,6 +16,8 @@ class SplitCacheStub: SplitCacheProtocol {
     var onSplitsUpdatedHandler: (([Split]) -> Void)? = nil
     private var changeNumber: Int64
     private var splits: [String:Split]
+    var timestamp = 0
+
     var clearCallCount = 0
     init(splits: [Split], changeNumber: Int64) {
         self.changeNumber = changeNumber
@@ -69,5 +71,12 @@ class SplitCacheStub: SplitCacheProtocol {
     func exists(trafficType: String) -> Bool {
         return true
     }
-    
+
+    func getTimestamp() -> Int {
+        return timestamp
+    }
+
+    func updateTimestamp() {
+        
+    }
 }

--- a/SplitTests/Fake/SplitCacheStub.swift
+++ b/SplitTests/Fake/SplitCacheStub.swift
@@ -7,13 +7,16 @@
 //
 
 import Foundation
+import XCTest
 @testable import Split
 
 class SplitCacheStub: SplitCacheProtocol {
 
+    var clearExpectation: XCTestExpectation?
     var onSplitsUpdatedHandler: (([Split]) -> Void)? = nil
     private var changeNumber: Int64
     private var splits: [String:Split]
+    var clearCallCount = 0
     init(splits: [Split], changeNumber: Int64) {
         self.changeNumber = changeNumber
         self.splits = [String:Split]()
@@ -55,6 +58,12 @@ class SplitCacheStub: SplitCacheProtocol {
     }
     
     func clear() {
+        clearCallCount+=1
+        splits.removeAll()
+        changeNumber = -1
+        if let exp = clearExpectation {
+            exp.fulfill()
+        }
     }
     
     func exists(trafficType: String) -> Bool {

--- a/SplitTests/Fake/SplitCacheStub.swift
+++ b/SplitTests/Fake/SplitCacheStub.swift
@@ -76,7 +76,7 @@ class SplitCacheStub: SplitCacheProtocol {
         return timestamp
     }
 
-    func updateTimestamp() {
-        
+    func setTimestamp(timestamp: Int) {
+        self.timestamp = timestamp
     }
 }

--- a/SplitTests/Fake/SplitChangeFetcherStub.swift
+++ b/SplitTests/Fake/SplitChangeFetcherStub.swift
@@ -1,0 +1,29 @@
+//
+//  SplitChangeFetcherStub.swift
+//  SplitTests
+//
+//  Created by Javier L. Avrudsky on 05/05/2020.
+//  Copyright © 2020 Split. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Split
+
+class SplitChangeFetcherStub: SplitChangeFetcher {
+    var fetchExpectation: XCTestExpectation?
+    var since: Int64 = -1
+    var fetchCallCount = 0
+    func fetch(since: Int64, policy: FecthingPolicy) throws -> SplitChange? {
+        self.since = since
+        let change = SplitChange()
+        change.splits = [Split]()
+        change.since = since + 100
+        change.till = since + 200
+        fetchCallCount+=1
+        if let exp = fetchExpectation {
+            exp.fulfill()
+        }
+        return change
+    }
+}

--- a/SplitTests/Fake/SplitEventsManagerStub.swift
+++ b/SplitTests/Fake/SplitEventsManagerStub.swift
@@ -1,0 +1,33 @@
+//
+// SplitEventsManagerStub.swift
+// Split
+//
+// Created by Javier L. Avrudsky on 05/05/2020.
+// Copyright (c) 2020  All rights reserved.
+//
+
+import Foundation
+@testable import Split
+class SplitEventsManagerStub: SplitEventsManager {
+    func notifyInternalEvent(_ event: SplitInternalEvent) {
+
+    }
+
+    func getExecutorResources() -> SplitEventExecutorResources {
+        fatalError("getExecutorResources() has not been implemented")
+    }
+
+    func register(event: SplitEvent, task: SplitEventTask) {
+    }
+
+    func start() {
+    }
+
+    func eventAlreadyTriggered(event: SplitEvent) -> Bool {
+        return false
+    }
+
+    func getExecutionTimes() -> [String: Int] {
+        return [String: Int]()
+    }
+}

--- a/SplitTests/RefreshableSplitFetcherTest.swift
+++ b/SplitTests/RefreshableSplitFetcherTest.swift
@@ -1,0 +1,88 @@
+//
+//  RefreshableSplitFetcherTest.swift
+//  SplitTests
+//
+//  Created by Javier L. Avrudsky on 05/05/2020.
+//  Copyright © 2020 Split. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+@testable import Split
+
+class RefreshableSplitFetcherTest: XCTestCase {
+
+    private var splitCache: SplitCacheStub!
+    private var splitChangeFetcher: SplitChangeFetcherStub!
+    private var changeNumber: Int64!
+
+    override func setUp() {
+        changeNumber = Int64((Date().timeIntervalSince1970 - 60 * 24 * 5) * 1000)
+        splitCache = SplitCacheStub(splits: generateSplits(), changeNumber: changeNumber)
+        splitChangeFetcher = SplitChangeFetcherStub()
+    }
+
+
+    func testClearExpiredCache() {
+        let fetcher = DefaultRefreshableSplitFetcher(splitChangeFetcher: splitChangeFetcher,
+                splitCache: splitCache,
+                interval: 1,
+                cacheExpiration: 60 * 23,
+                dispatchGroup: nil,
+                eventsManager: SplitEventsManagerStub())
+        let expectation = XCTestExpectation(description: "Clear")
+        splitCache.clearExpectation = expectation
+
+        fetcher.start()
+
+        wait(for: [expectation], timeout: 40)
+        XCTAssertEqual(splitCache.clearCallCount, 1)
+        XCTAssertEqual(splitCache.getChangeNumber(), Int64(-1))
+    }
+
+    func testClearNonExpiredCache() {
+        let fetcher = DefaultRefreshableSplitFetcher(splitChangeFetcher: splitChangeFetcher,
+                splitCache: splitCache,
+                interval: 1,
+                cacheExpiration: 60 * 24 * 10,
+                dispatchGroup: nil,
+                eventsManager: SplitEventsManagerStub())
+        let expectation = XCTestExpectation(description: "Clear")
+        splitChangeFetcher.fetchExpectation = expectation
+
+        fetcher.start()
+
+        wait(for: [expectation], timeout: 40)
+        XCTAssertEqual(splitCache.clearCallCount, 0)
+        XCTAssertEqual(splitCache.getChangeNumber(), changeNumber)
+    }
+
+    func testClearMinusOneChangeNumberCache() {
+        splitCache = SplitCacheStub(splits: generateSplits(), changeNumber: -1)
+        let fetcher = DefaultRefreshableSplitFetcher(splitChangeFetcher: splitChangeFetcher,
+                splitCache: splitCache,
+                interval: 1,
+                cacheExpiration: 60 * 24 * 10,
+                dispatchGroup: nil,
+                eventsManager: SplitEventsManagerStub())
+        let expectation = XCTestExpectation(description: "Clear")
+        splitChangeFetcher.fetchExpectation = expectation
+
+        fetcher.start()
+
+        wait(for: [expectation], timeout: 40)
+        XCTAssertEqual(splitCache.clearCallCount, 0)
+        XCTAssertEqual(splitCache.getChangeNumber(), -1)
+    }
+
+    private func generateSplits() -> [Split] {
+        var splits = [Split]()
+        for i in 1..<10 {
+            let s = Split()
+            s.name = "s\(i)"
+            splits.append(s)
+        }
+        return splits
+    }
+}


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Added timestamp to saved splits on disk
- Removing old splits based on new timestamp
- Added new UT