### PR TITLE
SDKS-1579: Fixing issue caused for Decimal(double:) constructor when parsing json

### DIFF
--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		599EDAF12270970500D7DACB /* SplitEventsManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599EDAF02270970500D7DACB /* SplitEventsManagerMock.swift */; };
 		599EDAF32270A15B00D7DACB /* localhost.splits in Resources */ = {isa = PBXBuildFile; fileRef = 599EDAF22270A15B00D7DACB /* localhost.splits */; };
 		599EDAF52270AD6700D7DACB /* wrong_format.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 599EDAF42270AD6700D7DACB /* wrong_format.yaml */; };
+		59AD7ACA2465C32D00F5B0B4 /* EventDTOJsonTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD7AC92465C32D00F5B0B4 /* EventDTOJsonTest.swift */; };
 		59AD7FD322F38BEF00F569C3 /* TrackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD7FD222F38BEF00F569C3 /* TrackManager.swift */; };
 		59B8B8AA220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B8B8A9220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift */; };
 		59B8B8AC220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B8B8AB220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift */; };
@@ -554,6 +555,7 @@
 		599EDAF02270970500D7DACB /* SplitEventsManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitEventsManagerMock.swift; sourceTree = "<group>"; };
 		599EDAF22270A15B00D7DACB /* localhost.splits */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = localhost.splits; sourceTree = "<group>"; };
 		599EDAF42270AD6700D7DACB /* wrong_format.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wrong_format.yaml; sourceTree = "<group>"; };
+		59AD7AC92465C32D00F5B0B4 /* EventDTOJsonTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDTOJsonTest.swift; sourceTree = "<group>"; };
 		59AD7FD222F38BEF00F569C3 /* TrackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackManager.swift; sourceTree = "<group>"; };
 		59B8B8A9220B1091003E0D5A /* SyncDictionaryCollectionWrapperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SyncDictionaryCollectionWrapperTest.swift; path = SplitTests/SyncDictionaryCollectionWrapperTest.swift; sourceTree = SOURCE_ROOT; };
 		59B8B8AB220B279F003E0D5A /* SyncDictionarySingleWrapperTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncDictionarySingleWrapperTest.swift; sourceTree = "<group>"; };
@@ -1160,6 +1162,7 @@
 				599A6E2C22F8C65500D3D68C /* ImpressionsManagerTest.swift */,
 				594677E322CFF30B00F94E58 /* TreatmentManagerTest.swift */,
 				59BF90B8239A75520007A896 /* VersionTest.swift */,
+				59AD7AC92465C32D00F5B0B4 /* EventDTOJsonTest.swift */,
 			);
 			path = SplitTests;
 			sourceTree = "<group>";
@@ -1732,6 +1735,7 @@
 				599A6E2D22F8C65500D3D68C /* ImpressionsManagerTest.swift in Sources */,
 				5982D9C421B04FA400230F44 /* MySegmentsCacheTests.swift in Sources */,
 				598EDE7E224BD1A6005D4762 /* MySegmentsFetcherStub.swift in Sources */,
+				59AD7ACA2465C32D00F5B0B4 /* EventDTOJsonTest.swift in Sources */,
 				59FB7C1621F79B8200ECC96A /* EventTypeNameHelper.swift in Sources */,
 				593AE9F3226F4068000D61B0 /* MySegmentsFetcherTests.swift in Sources */,
 				5959C479227B89980064F968 /* FactoryRegistryTest.swift in Sources */,

--- a/Split/Track/Models/EventDTO.swift
+++ b/Split/Track/Models/EventDTO.swift
@@ -38,9 +38,22 @@ class EventDTO: DynamicCodable {
         jsonObject["key"] = key
         jsonObject["eventTypeId"] = eventTypeId
         jsonObject["trafficTypeName"] = trafficTypeName
-        jsonObject["value"] = value
+        // Workaround to avoid lost of precision of Decimal(double:) constructor
+        jsonObject["value"] = Decimal(string: String(value ?? 0))
         jsonObject["timestamp"] = timestamp
-        jsonObject["properties"] = properties
+        var parsedProps: [String: Any]?
+        if let properties = properties {
+            parsedProps = [String: Any]()
+            for (propKey, propValue) in properties {
+                // Workaround to avoid lost of precision of Decimal(double:) constructor
+                if let doubleValue = propValue as? Double {
+                    parsedProps?[propKey] = Decimal(string: String(doubleValue))
+                } else {
+                    parsedProps?[propKey] = propValue
+                }
+            }
+        }
+        jsonObject["properties"] = parsedProps
         return jsonObject
     }
 }

--- a/SplitTests/EventDTOJsonTest.swift
+++ b/SplitTests/EventDTOJsonTest.swift
@@ -1,0 +1,136 @@
+//
+//  EventDTOJsonTest.swift
+//  SplitTests
+//
+//  Created by Javier L. Avrudsky on 08/05/2020.
+//  Copyright © 2020 Split. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Split
+
+class EventDTOJsonTest: XCTestCase {
+
+    func testBasic() {
+
+        let event = try? basicEvent(value: 12.0)
+
+        let jsonEvent = try? Json.dynamicEncodeToJson(event!)
+        let testEvent  = try? Json.dynamicEncodeFrom(json: jsonEvent!, to: EventDTO.self)
+
+        XCTAssertEqual(event?.key, testEvent?.key)
+        XCTAssertEqual(event?.eventTypeId, testEvent?.eventTypeId)
+        XCTAssertEqual(event?.trafficTypeName, testEvent?.trafficTypeName)
+        XCTAssertEqual(event?.value, testEvent?.value)
+    }
+
+    func testPropertiesDecodeEncode() {
+
+        let event = try? basicEvent(value: 12.00001)
+        let props: [String: Any] = [
+            "valueString": "string",
+            "valueTrue": true,
+            "valueFalse": false,
+            "value0": 0.1,
+            "value1": 12.0,
+            "value2": 22.1,
+            "value3": 1205.06,
+            "value4": 22.10001,
+            "value5": 2267.1000109,
+            "value6": 9900.0000001,
+            "value7": 9900.0000001979797979797970100101,
+            "value8": 999999999999.999999999999999999999999,
+        ]
+        event?.properties = props
+
+        let jsonEvent = try? Json.dynamicEncodeToJson(event!)
+        let testEvent  = try? Json.dynamicEncodeFrom(json: jsonEvent!, to: EventDTO.self)
+
+        let testProps = testEvent?.properties
+
+        XCTAssertEqual(event?.value, testEvent?.value)
+        XCTAssertEqual(props["valueString"] as? String, testProps?["valueString"] as? String)
+        XCTAssertTrue(testProps?["valueTrue"]! as! Bool)
+        XCTAssertFalse(testProps?["valueFalse"]! as! Bool)
+        XCTAssertEqual(props["value0"] as? Double, testProps?["value0"] as? Double)
+        XCTAssertEqual(props["value1"] as? Double, testProps?["value1"] as? Double)
+        XCTAssertEqual(props["value2"] as? Double, testProps?["value2"] as? Double)
+        XCTAssertEqual(props["value3"] as? Double, testProps?["value3"] as? Double)
+        XCTAssertEqual(props["value4"] as? Double, testProps?["value4"] as? Double)
+        XCTAssertEqual(props["value5"] as? Double, testProps?["value5"] as? Double)
+        XCTAssertEqual(props["value6"] as? Double, testProps?["value6"] as? Double)
+        XCTAssertEqual(props["value7"] as? Double, testProps?["value7"] as? Double)
+        XCTAssertEqual(props["value8"] as? Double, testProps?["value8"] as? Double)
+    }
+
+    func testProperties() {
+
+        let event = try? basicEvent(value: 12.00001)
+        let props: [String: Any] = [
+            "valueString": "string",
+            "valueTrue": true,
+            "valueFalse": false,
+            "value0": 0.1,
+            "value1": 12.0,
+            "value2": 22.1,
+            "value3": 1205.06,
+            "value4": 22.10001,
+            "value5": 2267.1000109,
+            "value6": 9900.0000001
+        ]
+        event?.properties = props
+
+        let jsonEvent = try? Json.dynamicEncodeToJson(event!)
+        let testEvent  = try? Json.dynamicEncodeFrom(json: jsonEvent!, to: EventDTO.self)
+
+        let testProps = testEvent?.properties
+
+        XCTAssertEqual("string", testProps?["valueString"] as? String)
+        XCTAssertEqual(0.1, testProps?["value0"] as? Double)
+        XCTAssertEqual(12.0, testProps?["value1"] as? Double)
+        XCTAssertEqual(22.1, testProps?["value2"] as? Double)
+        XCTAssertEqual(1205.06, testProps?["value3"] as? Double)
+        XCTAssertEqual(22.10001, testProps?["value4"] as? Double)
+        XCTAssertEqual(2267.1000109, testProps?["value5"] as? Double)
+        XCTAssertEqual(9900.0000001, testProps?["value6"] as? Double)
+    }
+
+
+    func testEncode() {
+
+        let jsonEvent = """
+        {\"key\":\"thekey\",\"eventTypeId\":\"event1\",\"properties\":{\"value2\":22.1,\"valueString\":\"string\",\"valueFalse\":false,\"value5\":2267.1000109,\"value3\":1205.06,\"value4\":22.10001,\"value1\":12,\"valueTrue\":true,\"value6\":9900.0000001,\"value0\":0.1},\"trafficTypeName\":\"custom\",\"value\":217.00001}
+        """
+
+        let testEvent  = try? Json.dynamicEncodeFrom(json: jsonEvent, to: EventDTO.self)
+
+        let testProps = testEvent?.properties
+
+        XCTAssertEqual("thekey", testEvent?.key)
+        XCTAssertEqual("event1", testEvent?.eventTypeId)
+        XCTAssertEqual("custom", testEvent?.trafficTypeName)
+        XCTAssertEqual(217.00001, testEvent?.value)
+        XCTAssertEqual("string", testProps?["valueString"] as? String)
+        XCTAssertEqual(0.1, testProps?["value0"] as? Double)
+        XCTAssertEqual(12.0, testProps?["value1"] as? Double)
+        XCTAssertEqual(22.1, testProps?["value2"] as? Double)
+        XCTAssertEqual(1205.06, testProps?["value3"] as? Double)
+        XCTAssertEqual(22.10001, testProps?["value4"] as? Double)
+        XCTAssertEqual(2267.1000109, testProps?["value5"] as? Double)
+        XCTAssertEqual(9900.0000001, testProps?["value6"] as? Double)
+    }
+
+    private func basicEvent(value: Double) throws -> EventDTO {
+        let jsonObject: [String: Any] = [
+            "key": "thekey",
+            "eventTypeId": "event1",
+            "trafficTypeName": "custom",
+            "value": value,
+            "timestamp": 11111111]
+
+        return try EventDTO(jsonObject: jsonObject)
+
+    }
+}
+


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Fixed issue about precision loss when sending  decimal track properties to server
- Added test for json parsing