### PR TITLE
Added first timestamp value validation when removing old split cache

### DIFF
--- a/Split.podspec
+++ b/Split.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
   s.module_name      = 'Split'
-  s.version          = '2.5.3-rc4'
+  s.version          = '2.5.3-rc5'
   s.summary          = 'iOS SDK for Split'
 
   s.description      = <<-DESC

--- a/Split/Common/Utils/Version.swift
+++ b/Split/Common/Utils/Version.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Version {
     private static let kSdkPlatform: String = "ios"
-    private static let kVersion = "2.5.3-rc4"
+    private static let kVersion = "2.5.3-rc5"
 
     static var semantic: String {
         return kVersion

--- a/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
+++ b/Split/FetcherEngine/Refresh/DefaultRefreshableSplitFetcher.swift
@@ -104,7 +104,7 @@ class DefaultRefreshableSplitFetcher: RefreshableSplitFetcher {
                 if changeNumber != -1 {
                     let timestamp = strongSelf.splitCache.getTimestamp()
                     let elapsedTime = Int(Date().timeIntervalSince1970) - timestamp
-                    if elapsedTime > strongSelf.cacheExpiration {
+                    if timestamp > 0 && elapsedTime > strongSelf.cacheExpiration {
                         changeNumber = -1
                         strongSelf.splitCache.clear()
                     }

--- a/SplitTests/RefreshableSplitFetcherTest.swift
+++ b/SplitTests/RefreshableSplitFetcherTest.swift
@@ -78,6 +78,24 @@ class RefreshableSplitFetcherTest: XCTestCase {
         XCTAssertEqual(splitCache.getChangeNumber(), -1)
     }
 
+    func testNoExpirationValueAvailableCache() {
+        let expiration: Int = 60 * 60 * 24 * 5 // Five days
+        let fetcher = DefaultRefreshableSplitFetcher(splitChangeFetcher: splitChangeFetcher,
+                splitCache: splitCache,
+                interval: 1,
+                cacheExpiration: expiration,
+                dispatchGroup: nil,
+                eventsManager: SplitEventsManagerStub())
+        let expectation = XCTestExpectation(description: "Clear")
+        splitChangeFetcher.fetchExpectation = expectation
+        splitCache.timestamp = 0 // No value
+        fetcher.start()
+
+        wait(for: [expectation], timeout: 40)
+        XCTAssertEqual(splitCache.clearCallCount, 0)
+        XCTAssertEqual(splitCache.getChangeNumber(), 1000)
+    }
+
     private func generateSplits() -> [Split] {
         var splits = [Split]()
         for i in 1..<10 {


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Validating splits cache when updating SDK version
- Added test