### PR TITLE
Updating interface client to make sync config available for Objc (Fetch specific splits)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2.5.4: (Ago 11, 2020)
+- Added `syncConfig.addFilter()` method to SDK configuration to pass a list of filters for the splits that will be downloaded. Read more in our docs.
+
 2.5.3: (Jun 30, 2020)
 - Fixed issue duplicating sent impressions
 - Fixed issue when rounding float values in json encoding/decoding

--- a/Split.podspec
+++ b/Split.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
   s.module_name      = 'Split'
-  s.version          = '2.5.3'
+  s.version          = '2.5.4-rc1'
   s.summary          = 'iOS SDK for Split'
   s.description      = <<-DESC
 This SDK is designed to work with Split, the platform for controlled rollouts, serving features to your users via the Split feature flag to manage your complete customer experience.

--- a/Split/Api/SplitFilter.swift
+++ b/Split/Api/SplitFilter.swift
@@ -53,10 +53,13 @@ import Foundation
         self.values = values.map {$0.trimmingCharacters(in: .whitespacesAndNewlines) }
     }
 
+    
+    @objc(byName:)
     public static func byName(_ values: [String]) -> SplitFilter {
         return SplitFilter(type: .byName, values: values)
     }
 
+    @objc(byPrefix:)
     public static func byPrefix(_ values: [String]) -> SplitFilter {
         return SplitFilter(type: .byPrefix, values: values)
     }

--- a/Split/Api/SyncConfig.swift
+++ b/Split/Api/SyncConfig.swift
@@ -15,13 +15,17 @@ import Foundation
         self.filters = filters
     }
 
+    @objc(builder)
     public static func builder() -> Builder {
         return Builder()
     }
 
-    public class Builder {
+    @objc(SyncConfigBuilder)
+    public class Builder: NSObject {
         private let splitValidator = SplitNameValidator()
         private var builderFilters = [SplitFilter]()
+
+        @objc(build)
         public func build() -> SyncConfig {
             var validatedFilters = [SplitFilter]()
             builderFilters.forEach { filter in
@@ -41,6 +45,8 @@ import Foundation
             return SyncConfig(filters: validatedFilters)
         }
 
+        @discardableResult
+        @objc(addSplitFilter:)
         public func addSplitFilter(_ filter: SplitFilter) -> SyncConfig.Builder {
             builderFilters.append(filter)
             return self

--- a/Split/Common/Utils/Version.swift
+++ b/Split/Common/Utils/Version.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Version {
     private static let kSdkPlatform: String = "ios"
-    private static let kVersion = "2.5.3"
+    private static let kVersion = "2.5.4-rc1"
 
     static var semantic: String {
         return kVersion


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
Added necessary ObjC attributes to SyncConfig and SplitFilter components