### PR TITLE
SDKS-1287: Old fetcher and storage file deprecation (cache revamp)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - development
+      - storage_revamp_baseline
 
 jobs:
   build:

--- a/Split/FetcherEngine/Cache/InMemoryMySegmentsCache.swift
+++ b/Split/FetcherEngine/Cache/InMemoryMySegmentsCache.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class InMemoryMySegmentsCache: MySegmentsCacheProtocol {
     private let queueName = "split.inmemcache-queue.mysegments"
     private var queue: DispatchQueue

--- a/Split/FetcherEngine/Cache/InMemorySplitCache.swift
+++ b/Split/FetcherEngine/Cache/InMemorySplitCache.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class InMemorySplitCache: NSObject, SplitCacheProtocol {
 
     private let queueName = "split.inmemcache-queue.splits"

--- a/Split/FetcherEngine/Cache/MySegmentsCache.swift
+++ b/Split/FetcherEngine/Cache/MySegmentsCache.swift
@@ -14,7 +14,7 @@ import Foundation
 /// from the server and it is saved to disk when application goes to background.
 /// In order to separate segments from different matching keys
 /// there is one file per each one of them.
-
+@available(*, deprecated, message: "To be removed in integration PR")
 class MySegmentsCache: MySegmentsCacheProtocol {
 
     private struct MySegmentsFile: Codable {

--- a/Split/FetcherEngine/Cache/MySegmentsCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/MySegmentsCacheProtocol.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+@available(*, deprecated, message: "To be removed in integration PR")
 protocol MySegmentsCacheProtocol {
     func setSegments(_ segments: [String])
     func removeSegments()

--- a/Split/FetcherEngine/Cache/SplitCache.swift
+++ b/Split/FetcherEngine/Cache/SplitCache.swift
@@ -14,6 +14,7 @@ import Foundation
 /// In memory splits are updated each time new information is retrieved
 /// from the server and it is saved to disk when application goes to background.
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class SplitCache: SplitCacheProtocol {
 
     struct SplitsFile: Codable {

--- a/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/SplitCacheProtocol.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 protocol SplitCacheProtocol {
     func addSplit(splitName: String, split: Split)
     func setChangeNumber(_ changeNumber: Int64)

--- a/Split/FetcherEngine/Cache/SplitChangeCache.swift
+++ b/Split/FetcherEngine/Cache/SplitChangeCache.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class  SplitChangeCache: SplitChangeCacheProtocol {
 
     private let queue = DispatchQueue(label: "io.Split.FetcherEngine.Cache.SplitChangeCache.SyncQueue")

--- a/Split/FetcherEngine/Cache/SplitChangeCacheProtocol.swift
+++ b/Split/FetcherEngine/Cache/SplitChangeCacheProtocol.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 protocol SplitChangeCacheProtocol {
 
     func addChange(splitChange: SplitChange) -> Bool

--- a/Split/FetcherEngine/HttpMySegmentsFetcher.swift
+++ b/Split/FetcherEngine/HttpMySegmentsFetcher.swift
@@ -1,5 +1,5 @@
 //
-//  NewHttpMySegmentsFetcher.swift
+//  HttpMySegmentsFetcher.swift
 //  Split
 //
 //  Created by Javier Avrudsky on 02-Dic-2020

--- a/Split/FetcherEngine/HttpSplitChangeFetcher.swift
+++ b/Split/FetcherEngine/HttpSplitChangeFetcher.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 public enum FecthingPolicy {
     case cacheOnly
     case networkAndCache
     case network
 }
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class HttpSplitChangeFetcher: NSObject, SplitChangeFetcher {
 
     private let restClient: RestClientSplitChanges

--- a/Split/FetcherEngine/HttpSplitFetcher.swift
+++ b/Split/FetcherEngine/HttpSplitFetcher.swift
@@ -1,10 +1,8 @@
 //
 //  HttpSplitFetcher.swift
-//  Pods
+//  Split
 //
-//  Created by Brian Sztamfater on 19/9/17.
-//
-//
+//  Created by Javier Avrudsky on 02-Dic-2020
 
 import Foundation
 

--- a/Split/FetcherEngine/MySegmentsChangeFetcher.swift
+++ b/Split/FetcherEngine/MySegmentsChangeFetcher.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 protocol MySegmentsChangeFetcher {
     func fetch(user: String, policy: FecthingPolicy) throws -> [String]?
 }
 
+@available(*, deprecated, message: "To be removed in integration PR")
 extension MySegmentsChangeFetcher {
     func fetch(user: String, policy: FecthingPolicy = .networkAndCache) throws -> [String]? {
         return try fetch(user: user, policy: policy)

--- a/Split/FetcherEngine/OldHttpMySegmentsFetcher.swift
+++ b/Split/FetcherEngine/OldHttpMySegmentsFetcher.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 class OldHttpMySegmentsFetcher: NSObject, MySegmentsChangeFetcher {
 
     private let restClient: RestClientMySegments

--- a/Split/FetcherEngine/Refresh/LocalSplitFetcher.swift
+++ b/Split/FetcherEngine/Refresh/LocalSplitFetcher.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-
+@available(*, deprecated, message: "Storage revamp. Check localhost on integration")
 class LocalSplitFetcher: SplitFetcher {
 
     private let splitCache: SplitCacheProtocol

--- a/Split/FetcherEngine/Refresh/MySegmentsFetcher.swift
+++ b/Split/FetcherEngine/Refresh/MySegmentsFetcher.swift
@@ -7,11 +7,12 @@
 //
 
 import Foundation
-
+@available(*, deprecated, message: "Storage revamp")
 protocol MySegmentsFetcher {
     func fetchAll() -> [String]
     func forceRefresh()
 }
 
+@available(*, deprecated, message: "Storage revamp")
 protocol RefreshableMySegmentsFetcher: MySegmentsFetcher, PeriodicTask {
 }

--- a/Split/FetcherEngine/Refresh/SplitFetcher.swift
+++ b/Split/FetcherEngine/Refresh/SplitFetcher.swift
@@ -7,12 +7,12 @@
 //
 
 import Foundation
-
+@available(*, deprecated, message: "Storage revamp")
 protocol SplitFetcher {
     func fetch(splitName: String) -> Split?
     func fetchAll() -> [Split]?
     func forceRefresh()
 }
-
+@available(*, deprecated, message: "Storage revamp")
 protocol RefreshableSplitFetcher: SplitFetcher, PeriodicTask {
 }

--- a/Split/FetcherEngine/SplitChangeFetcher.swift
+++ b/Split/FetcherEngine/SplitChangeFetcher.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@available(*, deprecated, message: "To be removed in integration PR")
 protocol SplitChangeFetcher {
     func fetch(since: Int64, policy: FecthingPolicy, clearCache: Bool) throws -> SplitChange?
 }

--- a/SplitTests/Helpers/TestingHelper.swift
+++ b/SplitTests/Helpers/TestingHelper.swift
@@ -28,8 +28,9 @@ struct TestingHelper {
 
     static func createImpressions(feature: String = "split", count: Int = 10) -> [Impression] {
         var impressions = [Impression]()
-        for _ in 0..<count {
+        for i in 0..<count {
             let impression = Impression()
+            impression.storageId = "\(feature)_impression\(i)"
             impression.feature = feature
             impression.keyName = "key1"
             impression.treatment = "t1"

--- a/SplitTests/Service/ImpressionsRecorderWorkerTests.swift
+++ b/SplitTests/Service/ImpressionsRecorderWorkerTests.swift
@@ -15,9 +15,12 @@ class ImpressionsRecorderWorkerTests: XCTestCase {
     var worker: ImpressionsRecorderWorker!
     var impressionStorage: PersistentImpressionsStorageStub!
     var impressionsRecorder: HttpImpressionsRecorderStub!
-    var dummyImpressions = TestingHelper.createImpressions(count: 11)
+    var dummyImpressions: [Impression]!
+
 
     override func setUp() {
+        dummyImpressions = TestingHelper.createImpressions(count: 5)
+        dummyImpressions.append(contentsOf: TestingHelper.createImpressions(feature: "split1", count: 6))
         impressionStorage = PersistentImpressionsStorageStub()
         impressionsRecorder = HttpImpressionsRecorderStub()
         worker = ImpressionsRecorderWorker(impressionsStorage: impressionStorage,
@@ -33,7 +36,7 @@ class ImpressionsRecorderWorkerTests: XCTestCase {
         worker.flush()
 
         XCTAssertEqual(6, impressionsRecorder.executeCallCount)
-        XCTAssertEqual(11, impressionsRecorder.impressionsSent.count)
+        XCTAssertEqual(11, impressionsRecorder.impressionsSent.flatMap { $0.keyImpressions }.count)
         XCTAssertEqual(0, impressionStorage.storedImpressions.count)
     }
 
@@ -48,7 +51,7 @@ class ImpressionsRecorderWorkerTests: XCTestCase {
 
         XCTAssertEqual(6, impressionsRecorder.executeCallCount)
         XCTAssertEqual(2, impressionStorage.storedImpressions.count)
-        XCTAssertEqual(9, impressionsRecorder.impressionsSent.count)
+        XCTAssertEqual(9, impressionsRecorder.impressionsSent.flatMap { $0.keyImpressions }.count)
     }
 
     func testSendOneImpression() {


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Marked old files as deprecated previous to integration