### PR TITLE
SDKS-2389: Added Ready From Cache Event

### DIFF
--- a/Split.podspec
+++ b/Split.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
   s.module_name      = 'Split'
-  s.version          = '2.9.0-rc9'
+  s.version          = '2.9.0-rc10'
   s.summary          = 'iOS SDK for Split'
   s.description      = <<-DESC
 This SDK is designed to work with Split, the platform for controlled rollouts, serving features to your users via the Split feature flag to manage your complete customer experience.

--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		957E666625D5B0EC006F5B19 /* StorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E666525D5B0EC006F5B19 /* StorageMigrator.swift */; };
 		957E667A25D5DD73006F5B19 /* StorageMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E667925D5DD73006F5B19 /* StorageMigratorTests.swift */; };
 		957E674C25E48753006F5B19 /* Bundle+Finder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E674B25E48753006F5B19 /* Bundle+Finder.swift */; };
+		957E676625E7F8D7006F5B19 /* ReadyFromCacheTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957E676525E7F8D7006F5B19 /* ReadyFromCacheTest.swift */; };
 		95F3EFEC258D26ED00084AF8 /* RecorderFlusherCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F3EFEB258D26ED00084AF8 /* RecorderFlusherCheckerTests.swift */; };
 		95F3EFF0258D2AFE00084AF8 /* PeriodicRecorderWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F3EFEF258D2AFE00084AF8 /* PeriodicRecorderWorker.swift */; };
 		95F3EFF4258D2C0300084AF8 /* RecorderWorkerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F3EFF3258D2C0300084AF8 /* RecorderWorkerStub.swift */; };
@@ -895,6 +896,7 @@
 		957E666525D5B0EC006F5B19 /* StorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMigrator.swift; sourceTree = "<group>"; };
 		957E667925D5DD73006F5B19 /* StorageMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMigratorTests.swift; sourceTree = "<group>"; };
 		957E674B25E48753006F5B19 /* Bundle+Finder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Finder.swift"; sourceTree = "<group>"; };
+		957E676525E7F8D7006F5B19 /* ReadyFromCacheTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyFromCacheTest.swift; sourceTree = "<group>"; };
 		95F3EFEB258D26ED00084AF8 /* RecorderFlusherCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderFlusherCheckerTests.swift; sourceTree = "<group>"; };
 		95F3EFEF258D2AFE00084AF8 /* PeriodicRecorderWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodicRecorderWorker.swift; sourceTree = "<group>"; };
 		95F3EFF3258D2C0300084AF8 /* RecorderWorkerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecorderWorkerStub.swift; sourceTree = "<group>"; };
@@ -1711,6 +1713,7 @@
 				599A6E3322FC681600D3D68C /* FlushTest.swift */,
 				596A7B70235729B5004F6139 /* DestroyTest.swift */,
 				596A7B5D234395C1004F6139 /* IntegrationHelper.swift */,
+				957E676525E7F8D7006F5B19 /* ReadyFromCacheTest.swift */,
 			);
 			path = Integration;
 			sourceTree = "<group>";
@@ -2448,6 +2451,7 @@
 				59B2043324F549B70092F2E9 /* SyncUpdateWorkerTest.swift in Sources */,
 				5912D14F2199FD8600BC698C /* LegacyHashingTest.swift in Sources */,
 				59FB7C282202457D00ECC96A /* LocalhostParserTests.swift in Sources */,
+				957E676625E7F8D7006F5B19 /* ReadyFromCacheTest.swift in Sources */,
 				59F4AAA124FFC94100A1C69A /* NotificationManagerKeeperTest.swift in Sources */,
 				59D84BDC2215CD52003DA248 /* LocalhostSplitFetcherTests.swift in Sources */,
 				599EA5852268E9C2006CBA89 /* LocalhostTests.swift in Sources */,

--- a/Split/Api/DefaultSplitFactory.swift
+++ b/Split/Api/DefaultSplitFactory.swift
@@ -108,7 +108,8 @@ public class DefaultSplitFactory: NSObject, SplitFactory {
                                                syncWorkerFactory: syncWorkerFactory,
                                                impressionsSyncHelper: impressionsSyncHelper,
                                                eventsSyncHelper: eventsSyncHelper,
-                                               splitsFilterQueryString: splitsFilterQueryString)
+                                               splitsFilterQueryString: splitsFilterQueryString,
+                                               splitEventsManager: eventsManager)
 
         let syncManager = SyncManagerBuilder().setUserKey(key.matchingKey).setStorageContainer(storageContainer)
             .setEndpointFactory(endpointFactory).setSplitApiFacade(apiFacade).setSynchronizer(synchronizer)

--- a/Split/Api/DefaultSplitFactoryBuilder.swift
+++ b/Split/Api/DefaultSplitFactoryBuilder.swift
@@ -83,8 +83,9 @@ import Foundation
         return self
     }
 
-    func setTestDatabase(_ database: SplitDatabase) {
+    func setTestDatabase(_ database: SplitDatabase) -> SplitFactoryBuilder {
         self.testDatabase = database
+        return self
     }
 
     public func build() -> SplitFactory? {

--- a/Split/Api/DefaultSplitManager.swift
+++ b/Split/Api/DefaultSplitManager.swift
@@ -16,7 +16,7 @@ import Foundation
     private let splitsStorage: SplitsStorage
     private let splitValidator: SplitValidator
     private let validationLogger: ValidationMessageLogger
-    private var isManagerDestroyed = false
+    private var isManagerDestroyed = Atomic(false)
 
     init(splitsStorage: SplitsStorage) {
         self.splitsStorage = splitsStorage
@@ -100,13 +100,13 @@ import Foundation
 extension DefaultSplitManager: Destroyable {
 
     func checkAndLogIfDestroyed(logTag: String) -> Bool {
-        if isManagerDestroyed {
+        if isManagerDestroyed.value {
             validationLogger.e(message: "Manager has already been destroyed - no calls possible", tag: logTag)
         }
-        return isManagerDestroyed
+        return isManagerDestroyed.value
     }
 
     func destroy() {
-        isManagerDestroyed = true
+        isManagerDestroyed.set(true)
     }
 }

--- a/Split/Common/Utils/Version.swift
+++ b/Split/Common/Utils/Version.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Version {
     private static let kSdkPlatform: String = "ios"
-    private static let kVersion = "2.9.0-rc9"
+    private static let kVersion = "2.9.0-rc10"
 
     static var semantic: String {
         return kVersion

--- a/Split/Engine/DefaultTreatmentManager.swift
+++ b/Split/Engine/DefaultTreatmentManager.swift
@@ -199,7 +199,8 @@ class DefaultTreatmentManager: TreatmentManager {
     }
 
     private func isSdkReady() -> Bool {
-        return eventsManager.eventAlreadyTriggered(event: SplitEvent.sdkReady)
+        return eventsManager.eventAlreadyTriggered(event: SplitEvent.sdkReadyFromCache) ||
+            eventsManager.eventAlreadyTriggered(event: SplitEvent.sdkReady)
     }
 
     func checkAndLogIfDestroyed(logTag: String) -> Bool {

--- a/Split/Events/Executors/SplitEventExecutorFactory.swift
+++ b/Split/Events/Executors/SplitEventExecutorFactory.swift
@@ -11,13 +11,6 @@ class SplitEventExecutorFactory {
     static func factory(event: SplitEvent,
                         task: SplitEventTask,
                         resources: SplitEventExecutorResources) -> SplitEventExecutorProtocol {
-
-        switch event {
-        case .sdkReady:
-            return SplitEventExecutorWithClient(task: task, client: resources.getClient())
-
-        case .sdkReadyTimedOut:
-            return SplitEventExecutorWithClient(task: task, client: resources.getClient())
-        }
+        return SplitEventExecutorWithClient(task: task, client: resources.getClient())
     }
 }

--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -10,6 +10,7 @@ import Foundation
 @objc public enum SplitEvent: Int {
     case sdkReady
     case sdkReadyTimedOut
+    case sdkReadyFromCache
 
     func toString() -> String {
         switch self {
@@ -17,6 +18,8 @@ import Foundation
             return "SDK_READY"
         case .sdkReadyTimedOut:
             return "SDK_READY_TIMED_OUT"
+        case .sdkReadyFromCache:
+            return "SDK_READY_FROM_CACHE"
         }
     }
 }

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -10,6 +10,8 @@ import Foundation
 public enum SplitInternalEvent {
     case mySegmentsAreReady
     case splitsAreReady
+    case mySegmentsLoadedFromCache
+    case splitsLoadedFromCache
     case sdkReadyTimeoutReached
     case splitsAreUpdated
     case mySegmentsAreUpdated

--- a/Split/Network/Streaming/Synchronizer.swift
+++ b/Split/Network/Streaming/Synchronizer.swift
@@ -59,6 +59,7 @@ class DefaultSynchronizer: Synchronizer {
     private let flusherEventsRecorderWorker: RecorderWorker
     private let eventsSyncHelper: EventsRecorderSyncHelper
     private let splitsFilterQueryString: String
+    private let splitEventsManager: SplitEventsManager
 
     init(splitConfig: SplitClientConfig,
          splitApiFacade: SplitApiFacade,
@@ -68,7 +69,9 @@ class DefaultSynchronizer: Synchronizer {
          eventsSyncHelper: EventsRecorderSyncHelper,
          syncTaskByChangeNumberCatalog: SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>
         = SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>(),
-         splitsFilterQueryString: String) {
+         splitsFilterQueryString: String,
+         splitEventsManager: SplitEventsManager) {
+
         self.splitConfig = splitConfig
         self.splitApiFacade = splitApiFacade
         self.splitStorageContainer = splitStorageContainer
@@ -88,20 +91,22 @@ class DefaultSynchronizer: Synchronizer {
         self.impressionsSyncHelper = impressionsSyncHelper
         self.eventsSyncHelper = eventsSyncHelper
         self.splitsFilterQueryString = splitsFilterQueryString
+        self.splitEventsManager = splitEventsManager
     }
 
     func loadAndSynchronizeSplits() {
         DispatchQueue.global().async {
             self.filterSplitsInCache()
             self.splitStorageContainer.splitsStorage.loadLocal()
+            self.splitEventsManager.notifyInternalEvent(.splitsLoadedFromCache)
             self.synchronizeSplits()
         }
-
     }
 
     func loadMySegmentsFromCache() {
         DispatchQueue.global().async {
             self.splitStorageContainer.mySegmentsStorage.loadLocal()
+            self.splitEventsManager.notifyInternalEvent(.mySegmentsLoadedFromCache)
         }
     }
 

--- a/Split/Network/Streaming/Synchronizer.swift
+++ b/Split/Network/Streaming/Synchronizer.swift
@@ -95,10 +95,13 @@ class DefaultSynchronizer: Synchronizer {
     }
 
     func loadAndSynchronizeSplits() {
+        let splitsStorage = self.splitStorageContainer.splitsStorage
         DispatchQueue.global().async {
             self.filterSplitsInCache()
-            self.splitStorageContainer.splitsStorage.loadLocal()
-            self.splitEventsManager.notifyInternalEvent(.splitsLoadedFromCache)
+            splitsStorage.loadLocal()
+            if splitsStorage.getAll().count > 0 {
+                self.splitEventsManager.notifyInternalEvent(.splitsLoadedFromCache)
+            }
             self.synchronizeSplits()
         }
     }
@@ -232,6 +235,7 @@ class DefaultSynchronizer: Synchronizer {
         }
         if toDelete.count > 0 {
             splitsStorage.delete(splitNames: toDelete)
+            splitStorageContainer.splitDatabase.generalInfoDao.update(info: .splitsChangeNumber, longValue: -1)
         }
     }
 

--- a/Split/Storage/Splits/PersistentSplitsStorage.swift
+++ b/Split/Storage/Splits/PersistentSplitsStorage.swift
@@ -64,6 +64,7 @@ class DefaultPersistentSplitsStorage: PersistentSplitsStorage {
     }
 
     func clear() {
+        generalInfoDao.update(info: .splitsChangeNumber, longValue: -1)
         splitDao.deleteAll()
     }
 }

--- a/SplitTests/Fake/SplitEventsManagerStub.swift
+++ b/SplitTests/Fake/SplitEventsManagerStub.swift
@@ -9,8 +9,17 @@
 import Foundation
 @testable import Split
 class SplitEventsManagerStub: SplitEventsManager {
+    var splitsLoadedEventFiredCount = 0
+    var mySegmentsLoadedEventFiredCount = 0
     func notifyInternalEvent(_ event: SplitInternalEvent) {
-
+        switch event {
+        case .mySegmentsLoadedFromCache:
+            mySegmentsLoadedEventFiredCount+=1
+        case .splitsLoadedFromCache:
+            splitsLoadedEventFiredCount+=1
+        default:
+            print("internal event fired: \(event)")
+        }
     }
 
     func getExecutorResources() -> SplitEventExecutorResources {

--- a/SplitTests/Integration/ReadyFromCacheTest.swift
+++ b/SplitTests/Integration/ReadyFromCacheTest.swift
@@ -1,0 +1,484 @@
+//
+//  ReadyFromCacheTest.swift
+//  SplitTests
+//
+//  Created by Javier Avrudsky on 25/02/2021.
+//  Copyright © 2021 Split. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import Split
+
+
+class ReadyFromCacheTest: XCTestCase {
+    var globalCacheReadyFired: Atomic<Bool>!
+    var globalReadyFired : Atomic<Bool>!
+    var jsonChanges: [String]!
+    var changes: [SplitChange]!
+    let splitName = "workm"
+    var streamingBinding: TestStreamResponseBinding?
+    var numbers = [500, 1000, 2000, 3000, 4000]
+    var changeHitIndex: AtomicInt!
+    var receivedChangeNumber: [Int64]!
+
+    override func setUp() {
+        receivedChangeNumber = Array(repeating: 0, count: 100)
+        globalCacheReadyFired = Atomic(false)
+        globalReadyFired = Atomic(false)
+        changeHitIndex = AtomicInt(0) // First hit will be with index == 0. Index == 0 if for cache
+        changes = [SplitChange]()
+        jsonChanges = [String]()
+        loadChanges()
+    }
+
+    func testExistingSplitsAndConnectionOk() {
+        // When splits and connection available, ready from cache and Ready should be fired
+        let splitDatabase = TestingHelper.createTestDatabase(name: "ready_from_cache_test")
+        splitDatabase.splitDao.insertOrUpdate(split: changes[0].splits[0])
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        let httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+        let splitConfig = basicSplitConfig()
+
+        let readyExp = XCTestExpectation()
+        let cacheReadyExp = XCTestExpectation()
+
+        var readyFired = false
+        var cacheReadyFired = false
+
+        let key: Key = Key(matchingKey: IntegrationHelper.dummyUserKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(splitDatabase)
+        let factory = builder.setApiKey(IntegrationHelper.dummyApiKey).setKey(key)
+            .setConfig(splitConfig).build()!
+
+        let client = factory.client
+
+        client.on(event: SplitEvent.sdkReadyFromCache) {
+            cacheReadyExp.fulfill()
+            cacheReadyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReady) {
+            readyExp.fulfill()
+            readyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReadyTimedOut) {
+            readyExp.fulfill()
+        }
+
+        wait(for: [cacheReadyExp], timeout: 1)
+        let treatmentCache = client.getTreatment(splitName)
+
+        globalCacheReadyFired.set(true)
+
+        ThreadUtils.delay(seconds: 5)
+        wait(for: [readyExp], timeout: 3)
+        let treatmentReady = client.getTreatment(splitName)
+
+        XCTAssertTrue(cacheReadyFired)
+        XCTAssertTrue(readyFired)
+        XCTAssertEqual("on0", treatmentCache)
+        XCTAssertEqual("on1", treatmentReady)
+    }
+
+    func testExistingSplitsAndNoConnection() {
+        // When splits and connection not available, ready from cache should be fired and Ready should NOT be fired
+        let splitDatabase = TestingHelper.createTestDatabase(name: "ready_from_cache_test")
+        splitDatabase.splitDao.insertOrUpdate(split: changes[0].splits[0])
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        let httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+        let splitConfig = basicSplitConfig()
+
+        let readyExp = XCTestExpectation()
+        let cacheReadyExp = XCTestExpectation()
+
+        var readyFired = false
+        var cacheReadyFired = false
+        var timeoutFired = false
+
+        let key: Key = Key(matchingKey: IntegrationHelper.dummyUserKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(splitDatabase)
+        let factory = builder.setApiKey(IntegrationHelper.dummyApiKey).setKey(key)
+            .setConfig(splitConfig).build()!
+
+        let client = factory.client
+
+        client.on(event: SplitEvent.sdkReadyFromCache) {
+            cacheReadyExp.fulfill()
+            cacheReadyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReady) {
+            readyExp.fulfill()
+            readyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReadyTimedOut) {
+            readyExp.fulfill()
+            timeoutFired = true
+        }
+
+        wait(for: [cacheReadyExp], timeout: 3)
+        let treatmentCache = client.getTreatment(splitName)
+
+        ThreadUtils.delay(seconds: 1)
+        wait(for: [readyExp], timeout: 3)
+        let treatmentReady = client.getTreatment(splitName)
+
+        XCTAssertTrue(cacheReadyFired)
+        XCTAssertFalse(readyFired)
+        XCTAssertTrue(timeoutFired)
+        XCTAssertEqual("on0", treatmentCache)
+        XCTAssertEqual("on0", treatmentReady)
+    }
+
+    func testNotExistingSplitsAndConnectionOk() {
+        // When NO splits and connection available, ready from cache should NOT be fired and Ready should be fired
+        let splitDatabase = TestingHelper.createTestDatabase(name: "ready_from_cache_test")
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        let httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+        let splitConfig = basicSplitConfig()
+
+        let readyExp = XCTestExpectation()
+
+        var readyFired = false
+        var cacheReadyFired = false
+        var timeoutFired = false
+
+        let key: Key = Key(matchingKey: IntegrationHelper.dummyUserKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(splitDatabase)
+        let factory = builder.setApiKey(IntegrationHelper.dummyApiKey).setKey(key)
+            .setConfig(splitConfig).build()!
+
+        let client = factory.client
+
+        client.on(event: SplitEvent.sdkReadyFromCache) {
+            cacheReadyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReady) {
+            readyExp.fulfill()
+            readyFired = true
+        }
+
+        client.on(event: SplitEvent.sdkReadyTimedOut) {
+            readyExp.fulfill()
+            timeoutFired = true
+        }
+
+        ThreadUtils.delay(seconds: 1)
+        let treatmentCache = client.getTreatment(splitName)
+
+        globalCacheReadyFired.set(true)
+
+        ThreadUtils.delay(seconds: 1)
+        wait(for: [readyExp], timeout: 3)
+        let treatmentReady = client.getTreatment(splitName)
+
+        XCTAssertFalse(cacheReadyFired)
+        XCTAssertTrue(readyFired)
+        XCTAssertFalse(timeoutFired)
+        XCTAssertEqual("control", treatmentCache)
+        XCTAssertEqual("on1", treatmentReady)
+    }
+
+    func testSplitsAndConnOk_FromNoSplitFilterToFilter() {
+        // When splits and connection available, ready from cache and Ready should be fired
+        let splitDatabase = TestingHelper.createTestDatabase(name: "ready_from_cache_test")
+        splitDatabase.splitDao.insertOrUpdate(split: changes[0].splits[0])
+        splitDatabase.generalInfoDao.update(info: .splitsChangeNumber, longValue: 100)
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        let httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+        let splitConfig = basicSplitConfig()
+
+        let key: Key = Key(matchingKey: IntegrationHelper.dummyUserKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(splitDatabase)
+
+        var treatmentsCache = [String]()
+        var treatmentsReady = [String]()
+
+        for i in 0..<2 {
+
+            let readyExp = XCTestExpectation()
+            let cacheReadyExp = XCTestExpectation()
+
+            if i == 1 {
+                let syncConfig = SyncConfig.builder()
+                    .addSplitFilter(SplitFilter.byName(["workm"]))
+                    .build()
+
+                splitConfig.sync = syncConfig
+            }
+
+
+            let factory = builder.setApiKey(IntegrationHelper.dummyApiKey).setKey(key)
+                .setConfig(splitConfig).build()!
+
+            let client = factory.client
+
+            client.on(event: SplitEvent.sdkReadyFromCache) {
+                cacheReadyExp.fulfill()
+            }
+
+            client.on(event: SplitEvent.sdkReady) {
+                readyExp.fulfill()
+            }
+
+            client.on(event: SplitEvent.sdkReadyTimedOut) {
+                readyExp.fulfill()
+            }
+
+            wait(for: [cacheReadyExp], timeout: 1)
+            treatmentsCache.insert(client.getTreatment(splitName), at: i)
+
+            globalCacheReadyFired.set(true)
+
+            ThreadUtils.delay(seconds: 2)
+            wait(for: [readyExp], timeout: 3)
+            treatmentsReady.insert(client.getTreatment(splitName), at: i)
+
+            globalCacheReadyFired.set(false)
+            client.destroy()
+            ThreadUtils.delay(seconds: 2)
+        }
+
+        XCTAssertEqual("on0", treatmentsCache[0])
+        XCTAssertEqual("on1", treatmentsReady[0])
+        XCTAssertEqual("on1", treatmentsCache[1])
+        XCTAssertEqual("on2", treatmentsReady[1])
+
+        XCTAssertEqual(100, receivedChangeNumber[1])
+        XCTAssertEqual(1000, receivedChangeNumber[2])
+    }
+
+    func testSplitsAndConnOk_FromSplitFilterToNoFilter() {
+        // When splits and connection available, ready from cache and Ready should be fired
+        changes = [SplitChange]()
+        jsonChanges = [String]()
+        loadChanges1()
+        let splitDatabase = TestingHelper.createTestDatabase(name: "ready_from_cache_test")
+        let split =  changes[0].splits[0]
+        let split1Name = "split1"
+        let split1Treatment = "t1"
+        let split1 = buildSplit(name: split1Name, treatment: split1Treatment)
+        splitDatabase.splitDao.insertOrUpdate(split: split)
+        splitDatabase.splitDao.insertOrUpdate(split: split1)
+        splitDatabase.generalInfoDao.update(info: .splitsChangeNumber, longValue: 100) // querytrings changes so change# from 100 to -1
+
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        let httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+        let splitConfig = basicSplitConfig()
+
+        var treatmentsCache = [Int: String]()
+        var treatmentsReady = [Int: String]()
+        var treatments1Cache = [Int: String]()
+        var treatments1Ready = [Int: String]()
+
+        for i in 0..<2 {
+            let key: Key = Key(matchingKey: IntegrationHelper.dummyUserKey)
+            let builder = DefaultSplitFactoryBuilder()
+            _ = builder.setHttpClient(httpClient)
+            _ = builder.setReachabilityChecker(ReachabilityMock())
+            _ = builder.setTestDatabase(splitDatabase)
+            let readyExp = XCTestExpectation()
+            let cacheReadyExp = XCTestExpectation()
+
+            if i == 0 {
+                let syncConfig = SyncConfig.builder()
+                    .addSplitFilter(SplitFilter.byName(["workm"]))
+                    .build()
+
+                splitConfig.sync = syncConfig
+            }
+
+            let factory = builder.setApiKey(IntegrationHelper.dummyApiKey).setKey(key)
+                .setConfig(splitConfig).build()!
+
+            let client = factory.client
+
+            client.on(event: SplitEvent.sdkReadyFromCache) {
+                cacheReadyExp.fulfill()
+            }
+
+            client.on(event: SplitEvent.sdkReady) {
+                readyExp.fulfill()
+            }
+
+            client.on(event: SplitEvent.sdkReadyTimedOut) {
+                readyExp.fulfill()
+            }
+
+            wait(for: [cacheReadyExp], timeout: 2)
+            treatmentsCache[i] = client.getTreatment(splitName)
+            treatments1Cache[i] = client.getTreatment(split1Name)
+
+            globalCacheReadyFired.set(true)
+
+            ThreadUtils.delay(seconds: 2)
+            wait(for: [readyExp], timeout: 3)
+            treatmentsReady[i] = client.getTreatment(splitName)
+            treatments1Ready[i] = client.getTreatment(split1Name)
+
+            globalCacheReadyFired.set(false)
+            client.destroy()
+            ThreadUtils.delay(seconds: 2)
+        }
+
+        XCTAssertEqual("on0", treatmentsCache[0])
+        XCTAssertEqual("on1", treatmentsReady[0])
+        XCTAssertEqual("on1", treatmentsCache[1])
+        XCTAssertEqual("on2", treatmentsReady[1])
+
+        XCTAssertEqual("control", treatments1Cache[0])
+        XCTAssertEqual("control", treatments1Ready[0])
+        XCTAssertEqual("control", treatments1Cache[1])
+        XCTAssertEqual("t1", treatments1Ready[1])
+
+        XCTAssertEqual(-1, receivedChangeNumber[1])
+        XCTAssertEqual(1000, receivedChangeNumber[2])
+    }
+
+    private func getChanges(for hitNumber: Int) -> Data {
+        if hitNumber < jsonChanges.count {
+            return Data(self.jsonChanges[hitNumber].utf8)
+        }
+        return Data(IntegrationHelper.emptySplitChanges(since: 999999, till: 999999).utf8)
+    }
+
+    private func buildTestDispatcher() -> HttpClientTestDispatcher {
+        self.changeHitIndex.set(1)
+        return { request in
+
+            print ("HIT: \(self.changeHitIndex.value)")
+            switch request.url.absoluteString {
+            case let(urlString) where urlString.contains("splitChanges"):
+                if self.globalCacheReadyFired.value {
+                    let changesIndex = self.changeHitIndex.getAndAdd(1)
+                    self.receivedChangeNumber[changesIndex] = request.parameters?["since"] as? Int64 ?? 0
+                    return TestDispatcherResponse(code: 200, data: self.getChanges(for: changesIndex))
+                }
+                return TestDispatcherResponse(code: 500, data: self.getChanges(for: 99999))
+
+            case let(urlString) where urlString.contains("mySegments"):
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
+
+            case let(urlString) where urlString.contains("auth"):
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.dummySseResponse().utf8))
+            default:
+                return TestDispatcherResponse(code: 500)
+            }
+        }
+    }
+
+    private func buildStreamingHandler() -> TestStreamResponseBindingHandler {
+        return { request in
+            self.streamingBinding = TestStreamResponseBinding.createFor(request: request, code: 200)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+            }
+            return self.streamingBinding!
+        }
+    }
+
+    private func getChanges(withIndex index: Int, since: Int, till: Int) -> SplitChange {
+        let change = IntegrationHelper.getChanges(fileName: "simple_split_change")
+        change?.since = Int64(since)
+        change?.till = Int64(till)
+        let split = change?.splits[0]
+        if let partitions = split?.conditions?[1].partitions {
+            for (i, partition) in partitions.enumerated() {
+                partition.treatment = "on\(i)"
+                if index == i {
+                    partition.size = 100
+
+                } else {
+                    partition.size = 0
+                }
+            }
+        }
+        return change!
+    }
+
+    private func buildSplit(name: String, treatment: String) -> Split {
+        let change = IntegrationHelper.getChanges(fileName: "simple_split_change")
+        change?.since = Int64(1)
+        change?.till = Int64(1)
+        let split = change!.splits[0]
+        split.name = name
+        if let partitions = split.conditions?[1].partitions {
+            for (i, partition) in partitions.enumerated() {
+                if 1 == i {
+                    partition.treatment = treatment
+                    partition.size = 100
+                } else {
+                    partition.treatment = "off"
+                    partition.size = 0
+                }
+            }
+        }
+        return split
+    }
+
+    private func loadChanges() {
+        for i in 0..<5 {
+            let change = getChanges(withIndex: i,
+                                    since: numbers[i],
+                                    till: numbers[i])
+
+            changes.append(change)
+            let json =  (try? Json.encodeToJson(change)) ?? ""
+            jsonChanges.insert(json, at: i)
+        }
+    }
+
+    private func loadChanges1() {
+        for i in 0..<5 {
+            let change = getChanges(withIndex: i,
+                                    since: numbers[i],
+                                    till: numbers[i])
+
+            if i==2 {
+                change.splits.append(buildSplit(name: "split1", treatment: "t1"))
+            }
+            changes.append(change)
+            let json =  (try? Json.encodeToJson(change)) ?? ""
+            jsonChanges.insert(json, at: i)
+        }
+    }
+
+    private func basicSplitConfig() -> SplitClientConfig {
+        let splitConfig: SplitClientConfig = SplitClientConfig()
+        splitConfig.featuresRefreshRate = 9999
+        splitConfig.segmentsRefreshRate = 9999
+        splitConfig.impressionRefreshRate = 999999
+        splitConfig.sdkReadyTimeOut = 3000
+        splitConfig.eventsPushRate = 999999
+        //splitConfig.isDebugModeEnabled = true
+        return splitConfig
+    }
+    
+}
+

--- a/SplitTests/Integration/SplitIntegrationTest.swift
+++ b/SplitTests/Integration/SplitIntegrationTest.swift
@@ -82,20 +82,15 @@ class SplitIntegrationTests: XCTestCase {
 
         let key: Key = Key(matchingKey: matchingKey, bucketingKey: nil)
         let builder = DefaultSplitFactoryBuilder()
-        builder.setTestDatabase(TestingHelper.createTestDatabase(name: "GralIntegrationTest"))
+        _ = builder.setTestDatabase(TestingHelper.createTestDatabase(name: "GralIntegrationTest"))
         var factory = builder.setApiKey(apiKey).setKey(key).setConfig(splitConfig).build()
 
         let client = factory?.client
         let manager = factory?.manager
 
         let sdkReadyExpectation = XCTestExpectation(description: "SDK READY Expectation")
-        var sdkReadyFromCacheFired = false
         var timeOutFired = false
         var sdkReadyFired = false
-
-        client?.on(event: SplitEvent.sdkReadyFromCache) {
-            sdkReadyFromCacheFired = true
-        }
 
         client?.on(event: SplitEvent.sdkReady) {
             sdkReadyFired = true
@@ -131,7 +126,6 @@ class SplitIntegrationTests: XCTestCase {
         let event99 = IntegrationHelper.getTrackEventBy(value: 99.0, trackHits: tracksHits())
         let event100 = IntegrationHelper.getTrackEventBy(value: 100.0, trackHits: tracksHits())
 
-        XCTAssertTrue(sdkReadyFromCacheFired)
         XCTAssertTrue(sdkReadyFired)
         XCTAssertFalse(timeOutFired)
         XCTAssertEqual("off", t1)

--- a/SplitTests/Integration/SplitIntegrationTest.swift
+++ b/SplitTests/Integration/SplitIntegrationTest.swift
@@ -89,8 +89,13 @@ class SplitIntegrationTests: XCTestCase {
         let manager = factory?.manager
 
         let sdkReadyExpectation = XCTestExpectation(description: "SDK READY Expectation")
+        var sdkReadyFromCacheFired = false
         var timeOutFired = false
         var sdkReadyFired = false
+
+        client?.on(event: SplitEvent.sdkReadyFromCache) {
+            sdkReadyFromCacheFired = true
+        }
 
         client?.on(event: SplitEvent.sdkReady) {
             sdkReadyFired = true
@@ -126,6 +131,7 @@ class SplitIntegrationTests: XCTestCase {
         let event99 = IntegrationHelper.getTrackEventBy(value: 99.0, trackHits: tracksHits())
         let event100 = IntegrationHelper.getTrackEventBy(value: 100.0, trackHits: tracksHits())
 
+        XCTAssertTrue(sdkReadyFromCacheFired)
         XCTAssertTrue(sdkReadyFired)
         XCTAssertFalse(timeOutFired)
         XCTAssertEqual("off", t1)

--- a/SplitTests/Streaming/SynchronizerTest.swift
+++ b/SplitTests/Streaming/SynchronizerTest.swift
@@ -32,7 +32,11 @@ class SynchronizerTest: XCTestCase {
 
     var synchronizer: Synchronizer!
 
+    var eventsManager: SplitEventsManagerStub!
+
     override func setUp() {
+
+        eventsManager = SplitEventsManagerStub()
         persistentSplitsStorage = PersistentSplitsStorageStub()
         splitsFetcher = HttpSplitFetcherStub()
 
@@ -86,7 +90,7 @@ class SynchronizerTest: XCTestCase {
                                                                  accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)),
             eventsSyncHelper: EventsRecorderSyncHelper(eventsStorage: PersistentEventsStorageStub(),
                                                                  accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)),
-            syncTaskByChangeNumberCatalog: updateWorkerCatalog, splitsFilterQueryString: "")
+            syncTaskByChangeNumberCatalog: updateWorkerCatalog, splitsFilterQueryString: "", splitEventsManager: eventsManager)
     }
 
     func testSyncAll() {
@@ -114,6 +118,7 @@ class SynchronizerTest: XCTestCase {
         XCTAssertTrue(persistentSplitsStorage.getAllCalled)
         XCTAssertTrue(persistentSplitsStorage.deleteCalled)
         XCTAssertTrue(splitsStorage.loadLocalCalled)
+        XCTAssertEqual(1, eventsManager.splitsLoadedEventFiredCount)
     }
 
     func testLoadMySegmentsFromCache() {
@@ -123,6 +128,7 @@ class SynchronizerTest: XCTestCase {
         ThreadUtils.delay(seconds: 0.2)
 
         XCTAssertTrue(mySegmentsStorage.loadLocalCalled)
+        XCTAssertEqual(1, eventsManager.mySegmentsLoadedEventFiredCount)
     }
 
     func testSynchronizeMySegments() {


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Triggering ready from cache event when splits are loaded
- Improved logic to update filtered splits before loading splits
- Added unit and integration tests