### PR TITLE
Improvement/info logging filter

### DIFF
--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -99,6 +99,18 @@ public class SplitClientConfig: NSObject {
     @objc public var serviceEndpoints = ServiceEndpoints.builder().build()
 
     ///
+    /// Enables/disables info messages in console, enabled by default.
+    ///
+    @objc public var isInfoModeEnabled: Bool {
+        get {
+            return Logger.shared.isInfoModeEnabled
+        }
+        set {
+            Logger.shared.isInfoModeEnabled = newValue
+        }
+    }
+    
+    ///
     /// Enables debug messages in console
     ///
     @objc public var isDebugModeEnabled: Bool {

--- a/Split/Common/Utils/Logger.swift
+++ b/Split/Common/Utils/Logger.swift
@@ -15,6 +15,7 @@ class Logger {
 
     private var isVerboseEnabled = false
     private var isDebugEnabled = false
+    private var isInfoEnabled = true // Enabled by default
 
     enum Level: String {
         case verbose = "VERBOSE"
@@ -53,6 +54,21 @@ class Logger {
             }
         }
     }
+    
+    var isInfoModeEnabled: Bool {
+        get {
+            var isEnabled = true
+            queue.sync {
+                isEnabled = self.isInfoEnabled
+            }
+            return isEnabled
+        }
+        set {
+            queue.async(flags: .barrier) {
+                self.isInfoEnabled = newValue
+            }
+        }
+    }
 
     static let shared: Logger = {
         let instance = Logger()
@@ -65,7 +81,10 @@ class Logger {
     }
 
     private func log(level: Logger.Level, msg: String, _ ctx: Any ...) {
-
+        if !isInfoModeEnabled && level == Logger.Level.info {
+            return
+        }
+        
         if !isDebugModeEnabled && level == Logger.Level.debug {
             return
         }


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
This pull request adds the ability to enable or disable info level console logs. Works the same way as the flag for debug or verbose logs.

## How do we test the changes introduced in this PR?
Setup an instance of `SplitClientConfig` with the field `isInfoModeEnabled` set to `false` and there shouldn't be any info level log output in the console. Remove the `isInfoModeEnabled` field or set it to the default value of `true` and the logs will again be present in the console.

## Extra Notes
Left info logs enabled by default so there is no noticeable change to the current behavior, but added the option for those who are only interested into error and warning logs and don't want their console cluttered with info level logs.