### PR TITLE
SDKS-2882: Clear memory cache on destroy

### DIFF
--- a/Split/Api/DefaultSplitFactory.swift
+++ b/Split/Api/DefaultSplitFactory.swift
@@ -118,6 +118,8 @@ public class DefaultSplitFactory: NSObject, SplitFactory {
             syncManager.stop()
             manager.destroy()
             eventsManager.stop()
+            storageContainer.mySegmentsStorage.destroy()
+            storageContainer.splitsStorage.destroy()
         }
 
         eventsManager.start()

--- a/Split/Api/LocalhostSplitClient.swift
+++ b/Split/Api/LocalhostSplitClient.swift
@@ -142,6 +142,8 @@ public final class LocalhostSplitClient: NSObject, SplitClient, InternalSplitCli
     }
 
     public func destroy() {
+        splitsStorage?.destroy()
+        mySegmentsStorage?.destroy()
     }
 
     public func destroy(completion: (() -> Void)?) {

--- a/Split/FetcherEngine/Refresh/EmptyMySegmentsStorage.swift
+++ b/Split/FetcherEngine/Refresh/EmptyMySegmentsStorage.swift
@@ -21,4 +21,7 @@ class EmptyMySegmentsStorage: MySegmentsStorage {
 
     func clear() {
     }
+
+    func destroy() {
+    }
 }

--- a/Split/FetcherEngine/Refresh/YamlSplitsStorage.swift
+++ b/Split/FetcherEngine/Refresh/YamlSplitsStorage.swift
@@ -126,6 +126,10 @@ class YamlSplitsStorage: SplitsStorage {
         taskExecutor?.stop()
     }
 
+    func destroy() {
+        inMemorySplits.removeAll()
+    }
+
     private func createTaskExecutor() -> PeriodicTaskExecutor {
         var config = PeriodicTaskExecutorConfig()
         config.firstExecutionWindow = refreshInterval

--- a/Split/Storage/MySegments/MySegmentsStorage.swift
+++ b/Split/Storage/MySegments/MySegmentsStorage.swift
@@ -13,6 +13,7 @@ protocol MySegmentsStorage {
     func getAll() -> Set<String>
     func set(_ segments: [String])
     func clear()
+    func destroy()
 }
 
 class DefaultMySegmentsStorage: MySegmentsStorage {
@@ -41,5 +42,9 @@ class DefaultMySegmentsStorage: MySegmentsStorage {
     func clear() {
         inMemoryMySegments.removeAll()
         persistenStorage.set([String]())
+    }
+
+    func destroy() {
+        inMemoryMySegments.removeAll()
     }
 }

--- a/Split/Storage/Splits/SplitsStorage.swift
+++ b/Split/Storage/Splits/SplitsStorage.swift
@@ -27,6 +27,7 @@ protocol SplitsStorage: SyncSplitsStorage {
     func updateWithoutChecks(split: Split)
     func isValidTrafficType(name: String) -> Bool
     func clear()
+    func destroy()
 }
 
 class DefaultSplitsStorage: SplitsStorage {
@@ -148,6 +149,10 @@ class DefaultSplitsStorage: SplitsStorage {
                 inMemorySplits.removeValue(forKey: splitName)
             }
         }
+    }
+
+    func destroy() {
+        inMemorySplits.removeAll()
     }
 }
 

--- a/SplitTests/Fake/MySegmentsStorageStub.swift
+++ b/SplitTests/Fake/MySegmentsStorageStub.swift
@@ -41,4 +41,7 @@ class MySegmentsStorageStub: MySegmentsStorage {
         }
         clearCalled = true
     }
+
+    func destroy() {
+    }
 }

--- a/SplitTests/Fake/Storage/SplitsStorageStub.swift
+++ b/SplitTests/Fake/Storage/SplitsStorageStub.swift
@@ -81,4 +81,8 @@ class SplitsStorageStub: SplitsStorage {
         clearCalled = true
         inMemorySplits.removeAll()
     }
+
+    func destroy() {
+        inMemorySplits.removeAll()
+    }
 }


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Removing splits and segments from memory when client is destroyed