### PR TITLE
SDKS-5597: Fixed notification name

### DIFF
--- a/Split/Network/Streaming/NotificationManagerKeeper.swift
+++ b/Split/Network/Streaming/NotificationManagerKeeper.swift
@@ -70,7 +70,7 @@ class DefaultNotificationManagerKeeper: NotificationManagerKeeper {
             self.telemetryProducer?.recordStreamingEvent(type: .streamingStatus,
                                                          data: TelemetryStreamingEventValue.streamingDisabled)
 
-        case .streamingEnabled:
+        case .streamingResumed:
             updateStreamingState(active: true)
             if publishersCount > 0 {
                 broadcasterChannel.push(event: .pushSubsystemUp)

--- a/Split/Network/Streaming/SseNotifications.swift
+++ b/Split/Network/Streaming/SseNotifications.swift
@@ -85,7 +85,7 @@ struct ControlNotification: NotificationTypeField {
     private (set) var type: NotificationType
 
     enum ControlType: Decodable {
-        case streamingEnabled
+        case streamingResumed
         case streamingDisabled
         case streamingPaused
         case streamingReset
@@ -98,8 +98,8 @@ struct ControlNotification: NotificationTypeField {
 
         static func enumFromString(string: String) -> ControlType {
             switch string.lowercased() {
-            case "streaming_enabled":
-                return ControlType.streamingEnabled
+            case "streaming_resumed":
+                return ControlType.streamingResumed
             case "streaming_disabled":
                 return ControlType.streamingDisabled
             case "streaming_paused":

--- a/SplitTests/Integration/streaming/StreamingControlTest.swift
+++ b/SplitTests/Integration/streaming/StreamingControlTest.swift
@@ -83,7 +83,7 @@ class StreamingControlTest: XCTestCase {
         syncSpy.stopPeriodicFetchingExp = XCTestExpectation()
         timestamp+=1000
         streamingBinding?.push(message: StreamingIntegrationHelper.controlMessage(timestamp: timestamp,
-                                                                                  controlType: "STREAMING_ENABLED"))
+                                                                                  controlType: "STREAMING_RESUMED"))
 
         wait(for: [syncSpy.stopPeriodicFetchingExp!], timeout: 5) // Polling stopped once streaming enabled
         timestamp+=1000

--- a/SplitTests/Integration/streaming/TelemetryIntegrationTest.swift
+++ b/SplitTests/Integration/streaming/TelemetryIntegrationTest.swift
@@ -238,7 +238,7 @@ class TelemetryIntegrationTest: XCTestCase {
 
         sseConnExp = XCTestExpectation()
         streamingBinding?.push(message: StreamingIntegrationHelper.controlMessage(timestamp: nextTimestap(),
-                                                                                  controlType: "STREAMING_ENABLED"))
+                                                                                  controlType: "STREAMING_RESUMED"))
 
         streamingBinding?.push(message: ":keepalive") // send keep alive to confirm streaming connection ok
         streamingBinding?.push(message: StreamingIntegrationHelper.controlMessage(timestamp: nextTimestap(),

--- a/SplitTests/Streaming/NotificationManagerKeeperTest.swift
+++ b/SplitTests/Streaming/NotificationManagerKeeperTest.swift
@@ -146,7 +146,7 @@ class NotificationManagerKeeperTest: XCTestCase {
 
         // reseting pushed event
         broadcasterChannel.lastPushedEvent = nil
-        let controlNotification = ControlNotification(type: .control, controlType: .streamingEnabled)
+        let controlNotification = ControlNotification(type: .control, controlType: .streamingResumed)
         notificationManager.handleIncomingControl(notification: controlNotification)
 
         XCTAssertEqual(PushStatusEvent.pushSubsystemUp, broadcasterChannel.lastPushedEvent)
@@ -191,7 +191,7 @@ class NotificationManagerKeeperTest: XCTestCase {
 
         // reseting pushed event
         broadcasterChannel.lastPushedEvent = nil
-        let controlNotification = ControlNotification(type: .control, controlType: .streamingEnabled)
+        let controlNotification = ControlNotification(type: .control, controlType: .streamingResumed)
         notificationManager.handleIncomingControl(notification: controlNotification)
 
         XCTAssertNil(broadcasterChannel.lastPushedEvent)

--- a/SplitTests/Streaming/NotificationParserTest.swift
+++ b/SplitTests/Streaming/NotificationParserTest.swift
@@ -45,7 +45,7 @@ class NotificationParserTest: XCTestCase {
 """
 
     let controlNotificationMessage = """
- {\"id\":\"x2dE2TEiJL:0:0\",\"clientId\":\"NDEzMTY5Mzg0MA==:OTc5Nzc4NDYz\",\"timestamp\":1584647533288,\"encoding\":\"json\",\"channel\":\"control_pri\",\"data\":\"{\\\"type\\\":\\\"CONTROL\\\",\\\"controlType\\\":\\\"STREAMING_ENABLED\\\"}\"}
+ {\"id\":\"x2dE2TEiJL:0:0\",\"clientId\":\"NDEzMTY5Mzg0MA==:OTc5Nzc4NDYz\",\"timestamp\":1584647533288,\"encoding\":\"json\",\"channel\":\"control_pri\",\"data\":\"{\\\"type\\\":\\\"CONTROL\\\",\\\"controlType\\\":\\\"STREAMING_RESUMED\\\"}\"}
 """
 
     let errorNotificationMessage = """
@@ -137,7 +137,7 @@ class NotificationParserTest: XCTestCase {
         let notification = try notificationParser.parseControl(jsonString: incoming!.jsonData!);
 
         XCTAssertEqual(NotificationType.control, notification.type);
-        XCTAssertEqual(ControlNotification.ControlType.streamingEnabled, notification.controlType);
+        XCTAssertEqual(ControlNotification.ControlType.streamingResumed, notification.controlType);
     }
 
 

--- a/SplitTests/Streaming/SseHandlerTest.swift
+++ b/SplitTests/Streaming/SseHandlerTest.swift
@@ -77,7 +77,7 @@ class SseHandlerTest: XCTestCase {
 
     func testIncomingControlStreaming() {
         notificationParser.incomingNotification = IncomingNotification(type: .control, jsonData: "dummy", timestamp: 100)
-        notificationParser.controlNotification = ControlNotification(type: .control, controlType: .streamingEnabled)
+        notificationParser.controlNotification = ControlNotification(type: .control, controlType: .streamingResumed)
         sseHandler.handleIncomingMessage(message: ["data": "{pepe}"])
 
         XCTAssertTrue(notificationManagerKeeper.handleIncomingControlCalled)


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Renamed notification name STREAMING_ENABLED to STREAMING_RESUMED