### PR TITLE
SDKS-5784: Evaluate without impressions - Impressions tracker refactor

### DIFF
--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -454,6 +454,7 @@
 		954F9C7025795CD300140B81 /* SplitsStorageStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F9C6F25795CD300140B81 /* SplitsStorageStub.swift */; };
 		954F9C75257961C100140B81 /* HttpSplitFetcherStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F9C74257961C100140B81 /* HttpSplitFetcherStub.swift */; };
 		954F9C7D2579697B00140B81 /* SplitChangeProcessorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F9C7C2579697B00140B81 /* SplitChangeProcessorStub.swift */; };
+		9550334A282F0FF400E5330F /* ImpressionsTrackerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95503349282F0FF400E5330F /* ImpressionsTrackerTest.swift */; };
 		9551666B276A46E000FE9D55 /* TelemetrySynchronizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9551666A276A46E000FE9D55 /* TelemetrySynchronizerTest.swift */; };
 		955423A326793AEF002278D5 /* ImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* ImpressionsObserver.swift */; };
 		955423A726794C58002278D5 /* LRUCacheTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A626794C58002278D5 /* LRUCacheTest.swift */; };
@@ -1321,6 +1322,7 @@
 		954F9C6F25795CD300140B81 /* SplitsStorageStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitsStorageStub.swift; sourceTree = "<group>"; };
 		954F9C74257961C100140B81 /* HttpSplitFetcherStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpSplitFetcherStub.swift; sourceTree = "<group>"; };
 		954F9C7C2579697B00140B81 /* SplitChangeProcessorStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitChangeProcessorStub.swift; sourceTree = "<group>"; };
+		95503349282F0FF400E5330F /* ImpressionsTrackerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsTrackerTest.swift; sourceTree = "<group>"; };
 		9551666A276A46E000FE9D55 /* TelemetrySynchronizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySynchronizerTest.swift; sourceTree = "<group>"; };
 		955423A226793AEF002278D5 /* ImpressionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsObserver.swift; sourceTree = "<group>"; };
 		955423A626794C58002278D5 /* LRUCacheTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCacheTest.swift; sourceTree = "<group>"; };
@@ -1524,6 +1526,7 @@
 				59ED408E24F06EC100EF7B09 /* TimersManagerTest.swift */,
 				59F4AAA72508120500A1C69A /* SyncManagerTest.swift */,
 				9519A92927DA9AF000278AEC /* SynchronizerTest.swift */,
+				95503349282F0FF400E5330F /* ImpressionsTrackerTest.swift */,
 				9519A93127DBC25B00278AEC /* MySegmentsSynchronizerTest.swift */,
 				9519A93927DE318000278AEC /* ByKeyFacadeTest.swift */,
 				59B2047524F9B8230092F2E9 /* PushManagerEventBroadcasterTest.swift */,
@@ -3329,6 +3332,7 @@
 				954F9C4E2577E6D200140B81 /* HttpSplitFetcherTests.swift in Sources */,
 				5932260124A4E91800496D8B /* HttpStreamRequestTest.swift in Sources */,
 				5946783522E110A700F94E58 /* MockWebServer.swift in Sources */,
+				9550334A282F0FF400E5330F /* ImpressionsTrackerTest.swift in Sources */,
 				595AD24D24E324D200A7B750 /* Base64UtilsTest.swift in Sources */,
 				599EDAF12270970500D7DACB /* SplitEventsManagerMock.swift in Sources */,
 				955B59632811E8E700D105CD /* SplitClientManagerTest.swift in Sources */,

--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -479,6 +479,8 @@
 		955B596C2816BC0C00D105CD /* MultiClientEvaluationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955B596B2816BC0C00D105CD /* MultiClientEvaluationTest.swift */; };
 		955BB4952820653F00762D7E /* SseClientFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955BB4942820653F00762D7E /* SseClientFactory.swift */; };
 		955BB49728229E9100762D7E /* SseClientFactoryStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955BB49628229E9100762D7E /* SseClientFactoryStub.swift */; };
+		955BB499282ABC9D00762D7E /* ImpressionsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955BB498282ABC9D00762D7E /* ImpressionsTracker.swift */; };
+		955BB49B282AF19B00762D7E /* ImpressionsTrackerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955BB49A282AF19B00762D7E /* ImpressionsTrackerStub.swift */; };
 		9560354327D01E8300E35BC8 /* MySegmentsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354227D01E8300E35BC8 /* MySegmentsStorage.swift */; };
 		9560354527D0F53300E35BC8 /* ConcurrentDictionarySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354427D0F53300E35BC8 /* ConcurrentDictionarySet.swift */; };
 		9560354927D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354827D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift */; };
@@ -1344,6 +1346,8 @@
 		955B596B2816BC0C00D105CD /* MultiClientEvaluationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiClientEvaluationTest.swift; sourceTree = "<group>"; };
 		955BB4942820653F00762D7E /* SseClientFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SseClientFactory.swift; sourceTree = "<group>"; };
 		955BB49628229E9100762D7E /* SseClientFactoryStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SseClientFactoryStub.swift; sourceTree = "<group>"; };
+		955BB498282ABC9D00762D7E /* ImpressionsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsTracker.swift; sourceTree = "<group>"; };
+		955BB49A282AF19B00762D7E /* ImpressionsTrackerStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsTrackerStub.swift; sourceTree = "<group>"; };
 		9560354227D01E8300E35BC8 /* MySegmentsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySegmentsStorage.swift; sourceTree = "<group>"; };
 		9560354427D0F53300E35BC8 /* ConcurrentDictionarySet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConcurrentDictionarySet.swift; sourceTree = "<group>"; };
 		9560354827D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByKeyMySegmentsStorageTests.swift; sourceTree = "<group>"; };
@@ -2434,6 +2438,7 @@
 				59B2043624F551420092F2E9 /* SseNotificationParserStub.swift */,
 				59B2043A24F568660092F2E9 /* SynchronizerStub.swift */,
 				95ED4AA826499D7D00FD3569 /* SynchronizerSpy.swift */,
+				955BB49A282AF19B00762D7E /* ImpressionsTrackerStub.swift */,
 				59F4AA9824FE8DA200A1C69A /* NotificationProcessorStub.swift */,
 				59F4AAA224FFCD5000A1C69A /* PushManagerEventBroadcasterStub.swift */,
 				59F4AA9E24FE9FA100A1C69A /* NotificiationManagerKeeperStub.swift */,
@@ -2675,6 +2680,7 @@
 				59F4AAD5251A8C3D00A1C69A /* SyncManagerBuilder.swift */,
 				59F4AAA92508131D00A1C69A /* SyncManager.swift */,
 				9519A91B27D942FF00278AEC /* Synchronizer.swift */,
+				955BB498282ABC9D00762D7E /* ImpressionsTracker.swift */,
 				9519A91927D7CC6500278AEC /* MySegmentsSynchronizer.swift */,
 				9519A93727DE2AE600278AEC /* ByKeyFacade.swift */,
 				95B180332767E5AC002DC9DF /* TelemetrySynchronizer.swift */,
@@ -2953,6 +2959,7 @@
 				3B6DEF1F20EA6AE50067435E /* SplitError.swift in Sources */,
 				955A5A53258D04DF00CAEE9F /* EventsRecorder.swift in Sources */,
 				3B6DEF5220EA6AE50067435E /* UserDefinedSegmentMatcherData.swift in Sources */,
+				955BB499282ABC9D00762D7E /* ImpressionsTracker.swift in Sources */,
 				9505682826836C4A001D7B10 /* RestClient+ImpressionsCount.swift in Sources */,
 				95B341B126136B42002F57F6 /* GlobalSecureStorage.swift in Sources */,
 				59FB7BD521E7C64700ECC96A /* SplitValidator.swift in Sources */,
@@ -3305,6 +3312,7 @@
 				95C717DE268CE137002ADB83 /* ImpressionsCountDaoStub.swift in Sources */,
 				592C6ABD211B718E002D120C /* DatesTests.swift in Sources */,
 				954F9B222571605600140B81 /* MySegmentsDaoStub.swift in Sources */,
+				955BB49B282AF19B00762D7E /* ImpressionsTrackerStub.swift in Sources */,
 				5912D14B2195F3C900BC698C /* FileStorageStub.swift in Sources */,
 				5905D4E8255B23DD006DA3B1 /* PersistentMySegmentsStorageStub.swift in Sources */,
 				953911B3267A97DF0040433A /* ImpressionHasherTest.swift in Sources */,

--- a/Split/Network/Sync/ImpressionsTracker.swift
+++ b/Split/Network/Sync/ImpressionsTracker.swift
@@ -1,0 +1,127 @@
+//
+//  ImpressionsTracker.swift
+//  Split
+//
+//  Created by Javier Avrudsky on 10-May-2022.
+//  Copyright © 2022 Split. All rights reserved.
+//
+
+import Foundation
+
+protocol ImpressionsTracker {
+    func start()
+    func pause()
+    func resume()
+    func stop()
+    func flush()
+    func push(_ impression: KeyImpression)
+    func destroy()
+}
+
+class DefaultImpressionsTracker: ImpressionsTracker {
+
+    private let syncWorkerFactory: SyncWorkerFactory
+    private let impressionsSyncHelper: ImpressionsRecorderSyncHelper
+    private let periodicImpressionsRecorderWoker: PeriodicRecorderWorker
+    private var periodicImpressionsCountRecorderWoker: PeriodicRecorderWorker?
+    private var flusherImpressionsCountRecorderWorker: RecorderWorker?
+    private let flusherImpressionsRecorderWorker: RecorderWorker
+    private let splitConfig: SplitClientConfig
+    private let impressionsObserver = ImpressionsObserver(size: ServiceConstants.lastSeenImpressionCachSize)
+    private let impressionsCounter = ImpressionsCounter()
+    private let storageContainer: SplitStorageContainer
+    private let telemetryProducer: TelemetryRuntimeProducer?
+
+    init(splitConfig: SplitClientConfig,
+         splitApiFacade: SplitApiFacade,
+         storageContainer: SplitStorageContainer,
+         syncWorkerFactory: SyncWorkerFactory,
+         impressionsSyncHelper: ImpressionsRecorderSyncHelper) {
+
+        self.splitConfig = splitConfig
+        self.syncWorkerFactory = syncWorkerFactory
+        self.storageContainer = storageContainer
+        self.flusherImpressionsRecorderWorker =
+            syncWorkerFactory.createImpressionsRecorderWorker(syncHelper: impressionsSyncHelper)
+        self.periodicImpressionsRecorderWoker =
+            syncWorkerFactory.createPeriodicImpressionsRecorderWorker(syncHelper: impressionsSyncHelper)
+        self.impressionsSyncHelper = impressionsSyncHelper
+        self.telemetryProducer = storageContainer.telemetryStorage
+
+        if isOptimizedImpressionsMode() {
+            self.periodicImpressionsCountRecorderWoker
+                = syncWorkerFactory.createPeriodicImpressionsCountRecorderWorker()
+            self.flusherImpressionsCountRecorderWorker
+                = syncWorkerFactory.createImpressionsCountRecorderWorker()
+        }
+    }
+
+    func start() {
+        periodicImpressionsRecorderWoker.start()
+    }
+
+    func stop() {
+        periodicImpressionsRecorderWoker.stop()
+    }
+
+    func push(_ impression: KeyImpression) {
+
+        // This should not happen
+        guard let featureName = impression.featureName else {
+            return
+        }
+
+        let impressionToPush = impression.withPreviousTime(
+            self.impressionsObserver.testAndSet(impression: impression))
+        if self.isOptimizedImpressionsMode() {
+            self.impressionsCounter.inc(featureName: featureName, timeframe: impressionToPush.time, amount: 1)
+        }
+
+        if !self.isOptimizedImpressionsMode() || self.shouldPush(impression: impressionToPush) {
+            if self.impressionsSyncHelper.pushAndCheckFlush(impressionToPush) {
+                self.flusherImpressionsRecorderWorker.flush()
+                self.impressionsSyncHelper.resetAccumulator()
+
+            }
+        } else {
+            self.telemetryProducer?.recordImpressionStats(type: .deduped, count: 1)
+        }
+
+    }
+
+    func pause() {
+        saveImpressionsCount()
+        periodicImpressionsRecorderWoker.pause()
+        periodicImpressionsCountRecorderWoker?.pause()
+    }
+
+    func resume() {
+        periodicImpressionsRecorderWoker.resume()
+        periodicImpressionsCountRecorderWoker?.resume()
+    }
+
+    func flush() {
+        self.flusherImpressionsRecorderWorker.flush()
+        self.flusherImpressionsCountRecorderWorker?.flush()
+        self.impressionsSyncHelper.resetAccumulator()
+    }
+
+    func destroy() {
+        periodicImpressionsRecorderWoker.destroy()
+    }
+
+    private func saveImpressionsCount() {
+        storageContainer.impressionsCountStorage.pushMany(counts: impressionsCounter.popAll())
+    }
+
+    private func isOptimizedImpressionsMode() -> Bool {
+        return ImpressionsMode.optimized == splitConfig.finalImpressionsMode
+    }
+
+    private func shouldPush(impression: KeyImpression) -> Bool {
+        guard let previousTime = impression.previousTime else {
+            return true
+        }
+        return Date.truncateTimeframe(millis: previousTime) != Date.truncateTimeframe(millis: impression.time)
+    }
+}

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -36,7 +36,7 @@ protocol Synchronizer: ImpressionLogger {
 }
 
 // TODO: Extract splits sync logic to a new component
-// TODO: Extract events and impressions related logic
+// TODO: Extract events logic
 class DefaultSynchronizer: Synchronizer {
 
     private let telemetrySynchronizer: TelemetrySynchronizer?
@@ -45,26 +45,22 @@ class DefaultSynchronizer: Synchronizer {
     private let syncWorkerFactory: SyncWorkerFactory
     private let syncTaskByChangeNumberCatalog: SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>
     private let splitConfig: SplitClientConfig
-    private let impressionsSyncHelper: ImpressionsRecorderSyncHelper
 
     private let periodicSplitsSyncWorker: PeriodicSyncWorker
     private let splitsSyncWorker: RetryableSyncWorker
-    private let periodicImpressionsRecorderWoker: PeriodicRecorderWorker
-    private var periodicImpressionsCountRecorderWoker: PeriodicRecorderWorker?
-    private var flusherImpressionsCountRecorderWorker: RecorderWorker?
-    private let flusherImpressionsRecorderWorker: RecorderWorker
+    
     private let periodicEventsRecorderWorker: PeriodicRecorderWorker
     private let flusherEventsRecorderWorker: RecorderWorker
 
     private let eventsSyncHelper: EventsRecorderSyncHelper
     private let splitsFilterQueryString: String
     private let splitEventsManager: SplitEventsManager
-    private let impressionsObserver = ImpressionsObserver(size: ServiceConstants.lastSeenImpressionCachSize)
-    private let impressionsCounter = ImpressionsCounter()
+
     private let flushQueue = DispatchQueue(label: "split-flush-queue", target: DispatchQueue.global())
     private let telemetryProducer: TelemetryRuntimeProducer?
     private let byKeySynchronizer: ByKeySynchronizer
     private let defaultUserKey: String
+    private let impressionsTracker: ImpressionsTracker
 
     private var isDestroyed = Atomic(false)
 
@@ -75,7 +71,7 @@ class DefaultSynchronizer: Synchronizer {
          splitApiFacade: SplitApiFacade,
          splitStorageContainer: SplitStorageContainer,
          syncWorkerFactory: SyncWorkerFactory,
-         impressionsSyncHelper: ImpressionsRecorderSyncHelper,
+         impressionsTracker: ImpressionsTracker,
          eventsSyncHelper: EventsRecorderSyncHelper,
          syncTaskByChangeNumberCatalog: SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>
         = SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>(),
@@ -90,27 +86,16 @@ class DefaultSynchronizer: Synchronizer {
         self.syncTaskByChangeNumberCatalog = syncTaskByChangeNumberCatalog
         self.periodicSplitsSyncWorker = syncWorkerFactory.createPeriodicSplitsSyncWorker()
         self.splitsSyncWorker = syncWorkerFactory.createRetryableSplitsSyncWorker()
-        self.flusherImpressionsRecorderWorker =
-            syncWorkerFactory.createImpressionsRecorderWorker(syncHelper: impressionsSyncHelper)
-        self.periodicImpressionsRecorderWoker =
-            syncWorkerFactory.createPeriodicImpressionsRecorderWorker(syncHelper: impressionsSyncHelper)
+        self.impressionsTracker = impressionsTracker
         self.flusherEventsRecorderWorker = syncWorkerFactory.createEventsRecorderWorker(syncHelper: eventsSyncHelper)
         self.periodicEventsRecorderWorker =
             syncWorkerFactory.createPeriodicEventsRecorderWorker(syncHelper: eventsSyncHelper)
-        self.impressionsSyncHelper = impressionsSyncHelper
         self.eventsSyncHelper = eventsSyncHelper
         self.splitsFilterQueryString = splitsFilterQueryString
         self.splitEventsManager = splitEventsManager
         self.telemetryProducer = splitStorageContainer.telemetryStorage
         self.telemetrySynchronizer = telemetrySynchronizer
         self.byKeySynchronizer = byKeyFacade
-
-        if isOptimizedImpressionsMode() {
-            self.periodicImpressionsCountRecorderWoker
-                = syncWorkerFactory.createPeriodicImpressionsCountRecorderWorker()
-            self.flusherImpressionsCountRecorderWorker
-                = syncWorkerFactory.createImpressionsCountRecorderWorker()
-        }
     }
 
     func loadAndSynchronizeSplits() {
@@ -203,16 +188,14 @@ class DefaultSynchronizer: Synchronizer {
     }
 
     func startPeriodicRecording() {
-        periodicImpressionsRecorderWoker.start()
+        impressionsTracker.start()
         periodicEventsRecorderWorker.start()
-        periodicImpressionsCountRecorderWoker?.start()
         telemetrySynchronizer?.start()
     }
 
     func stopPeriodicRecording() {
-        periodicImpressionsRecorderWoker.stop()
+        impressionsTracker.stop()
         periodicEventsRecorderWorker.stop()
-        periodicImpressionsCountRecorderWoker?.stop()
         telemetrySynchronizer?.destroy()
     }
 
@@ -228,28 +211,8 @@ class DefaultSynchronizer: Synchronizer {
 
     func pushImpression(impression: KeyImpression) {
 
-        // This should not happen
-        guard let featureName = impression.featureName else {
-            return
-        }
-
         flushQueue.async {
-            let impressionToPush = impression.withPreviousTime(
-                self.impressionsObserver.testAndSet(impression: impression))
-            if self.isOptimizedImpressionsMode() {
-                self.impressionsCounter.inc(featureName: featureName, timeframe: impressionToPush.time, amount: 1)
-            }
-
-            if !self.isOptimizedImpressionsMode() || self.shouldPush(impression: impressionToPush) {
-                self.telemetryProducer?.recordImpressionStats(type: .queued, count: 1)
-                if self.impressionsSyncHelper.pushAndCheckFlush(impressionToPush) {
-                    self.flusherImpressionsRecorderWorker.flush()
-                    self.impressionsSyncHelper.resetAccumulator()
-
-                }
-            } else {
-                self.telemetryProducer?.recordImpressionStats(type: .deduped, count: 1)
-            }
+            self.impressionsTracker.push(impression)
         }
     }
 
@@ -262,32 +225,27 @@ class DefaultSynchronizer: Synchronizer {
     }
 
     func pause() {
-        saveImpressionsCount()
+        impressionsTracker.pause()
         periodicSplitsSyncWorker.pause()
         byKeySynchronizer.pause()
         periodicEventsRecorderWorker.pause()
-        periodicImpressionsRecorderWoker.pause()
-        periodicImpressionsCountRecorderWoker?.pause()
         telemetrySynchronizer?.synchronizeStats()
         telemetrySynchronizer?.pause()
     }
 
     func resume() {
+        impressionsTracker.resume()
         periodicSplitsSyncWorker.resume()
         byKeySynchronizer.resume()
         periodicEventsRecorderWorker.resume()
-        periodicImpressionsRecorderWoker.resume()
-        periodicImpressionsCountRecorderWoker?.resume()
         telemetrySynchronizer?.resume()
     }
 
     func flush() {
         flushQueue.async {
-            self.flusherImpressionsRecorderWorker.flush()
+            self.impressionsTracker.flush()
             self.flusherEventsRecorderWorker.flush()
-            self.flusherImpressionsCountRecorderWorker?.flush()
             self.eventsSyncHelper.resetAccumulator()
-            self.impressionsSyncHelper.resetAccumulator()
             self.telemetrySynchronizer?.synchronizeStats()
         }
     }
@@ -298,8 +256,8 @@ class DefaultSynchronizer: Synchronizer {
         byKeySynchronizer.stop()
         periodicSplitsSyncWorker.stop()
         periodicSplitsSyncWorker.destroy()
-        periodicImpressionsRecorderWoker.destroy()
         periodicEventsRecorderWorker.destroy()
+        impressionsTracker.destroy()
         let updateTasks = syncTaskByChangeNumberCatalog.takeAll()
         for task in updateTasks.values {
             task.stop()
@@ -344,21 +302,6 @@ class DefaultSynchronizer: Synchronizer {
             return String(splitName[range.upperBound...])
         }
         return nil
-    }
-
-    private func saveImpressionsCount() {
-        splitStorageContainer.impressionsCountStorage.pushMany(counts: impressionsCounter.popAll())
-    }
-
-    private func isOptimizedImpressionsMode() -> Bool {
-        return ImpressionsMode.optimized == splitConfig.finalImpressionsMode
-    }
-
-    private func shouldPush(impression: KeyImpression) -> Bool {
-        guard let previousTime = impression.previousTime else {
-            return true
-        }
-        return Date.truncateTimeframe(millis: previousTime) != Date.truncateTimeframe(millis: impression.time)
     }
 
     private func recordSyncModeEvent(_ mode: Int64) {

--- a/SplitTests/Fake/Streaming/ImpressionsTrackerStub.swift
+++ b/SplitTests/Fake/Streaming/ImpressionsTrackerStub.swift
@@ -1,0 +1,47 @@
+//
+//  ImpressionsTrackerStub.swift
+//  SplitTests
+//
+//  Created by Javier Avrudsky on 10-May-2022.
+//  Copyright © 2022 Split. All rights reserved.
+//
+
+import Foundation
+@testable import Split
+
+class ImpressionsTrackStub: ImpressionsTracker {
+    var startCalled = false
+    func start() {
+        startCalled = true
+    }
+
+    var pauseCalled = false
+    func pause() {
+        pauseCalled = true
+    }
+
+    var resumeCalled = false
+    func resume() {
+        resumeCalled = true
+    }
+
+    var stopCalled = false
+    func stop() {
+        stopCalled = true
+    }
+
+    var flushCalled = false
+    func flush() {
+        flushCalled = true
+    }
+
+    var pushCalled = false
+    func push(_ impression: KeyImpression) {
+        pushCalled = true
+    }
+
+    var destroyCalled = false
+    func destroy() {
+        destroyCalled = true
+    }
+}

--- a/SplitTests/Fake/Streaming/ImpressionsTrackerStub.swift
+++ b/SplitTests/Fake/Streaming/ImpressionsTrackerStub.swift
@@ -9,7 +9,7 @@
 import Foundation
 @testable import Split
 
-class ImpressionsTrackStub: ImpressionsTracker {
+class ImpressionsTrackerStub: ImpressionsTracker {
     var startCalled = false
     func start() {
         startCalled = true

--- a/SplitTests/Fake/Streaming/SynchronizerSpy.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerSpy.swift
@@ -53,7 +53,7 @@ class SynchronizerSpy: Synchronizer {
          splitApiFacade: SplitApiFacade,
          splitStorageContainer: SplitStorageContainer,
          syncWorkerFactory: SyncWorkerFactory,
-         impressionsSyncHelper: ImpressionsRecorderSyncHelper,
+         impressionsTracker: ImpressionsTracker,
          eventsSyncHelper: EventsRecorderSyncHelper,
          syncTaskByChangeNumberCatalog: SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>
         = SyncDictionarySingleWrapper<Int64, RetryableSyncWorker>(),
@@ -68,7 +68,7 @@ class SynchronizerSpy: Synchronizer {
                                                      splitApiFacade: splitApiFacade,
                                                      splitStorageContainer: splitStorageContainer,
                                                      syncWorkerFactory: syncWorkerFactory,
-                                                     impressionsSyncHelper: impressionsSyncHelper,
+                                                     impressionsTracker: impressionsTracker,
                                                      eventsSyncHelper: eventsSyncHelper,
                                                      splitsFilterQueryString: splitsFilterQueryString,
                                                      splitEventsManager: splitEventsManager)

--- a/SplitTests/Helpers/TestSplitFactory.swift
+++ b/SplitTests/Helpers/TestSplitFactory.swift
@@ -118,6 +118,12 @@ class TestSplitFactory {
                                                          splitChangeProcessor: DefaultSplitChangeProcessor(),
                                                          eventsManager: eventsManager)
 
+        let impressionsTracker = DefaultImpressionsTracker(splitConfig: splitConfig,
+                                                           splitApiFacade: apiFacade,
+                                                           storageContainer: storageContainer,
+                                                           syncWorkerFactory: syncWorkerFactory,
+                                                           impressionsSyncHelper: impressionsSyncHelper)
+
         let byKeyFacade = DefaultByKeyFacade()
 
         self.synchronizer = SynchronizerSpy(splitConfig: splitConfig,
@@ -127,7 +133,7 @@ class TestSplitFactory {
                                             splitApiFacade: apiFacade,
                                             splitStorageContainer: storageContainer,
                                             syncWorkerFactory: syncWorkerFactory,
-                                            impressionsSyncHelper: impressionsSyncHelper,
+                                            impressionsTracker: impressionsTracker,
                                             eventsSyncHelper: eventsSyncHelper,
                                             splitsFilterQueryString: splitsFilterQueryString,
                                             splitEventsManager: eventsManager)

--- a/SplitTests/Streaming/ImpressionsTrackerTest.swift
+++ b/SplitTests/Streaming/ImpressionsTrackerTest.swift
@@ -12,65 +12,128 @@ import XCTest
 
 class ImpressionsTrackerTest: XCTestCase {
     var periodicImpressionsRecorderWorker: PeriodicRecorderWorkerStub!
+    var periodicImpressionsCountRecorderWorker: PeriodicRecorderWorkerStub!
     var impressionsRecorderWorker: RecorderWorkerStub!
+    var impressionsCountRecorderWorker: RecorderWorkerStub!
     var impressionsTracker: ImpressionsTracker!
     var syncWorkerFactory: SyncWorkerFactoryStub!
     var telemetryProducer: TelemetryStorageStub!
+    var impressionsStorage: PersistentImpressionsStorageStub!
+    var impressionsCountStorage: PersistentImpressionsCountStorageStub!
 
     override func setUp() {
         periodicImpressionsRecorderWorker = PeriodicRecorderWorkerStub()
+        periodicImpressionsCountRecorderWorker = PeriodicRecorderWorkerStub()
         impressionsRecorderWorker = RecorderWorkerStub()
+        impressionsCountRecorderWorker = RecorderWorkerStub()
 
         syncWorkerFactory = SyncWorkerFactoryStub()
 
-                syncWorkerFactory.periodicImpressionsRecorderWorker = periodicImpressionsRecorderWorker
-                syncWorkerFactory.impressionsRecorderWorker = impressionsRecorderWorker
+        syncWorkerFactory.periodicImpressionsRecorderWorker = periodicImpressionsRecorderWorker
+        syncWorkerFactory.impressionsRecorderWorker = impressionsRecorderWorker
+        syncWorkerFactory.periodicImpressionsCountRecorderWorker = periodicImpressionsCountRecorderWorker
+        syncWorkerFactory.impressionsCountRecorderWorker = impressionsCountRecorderWorker
 
 
-                telemetryProducer = TelemetryStorageStub()
+        telemetryProducer = TelemetryStorageStub()
+        impressionsStorage = PersistentImpressionsStorageStub()
+        impressionsCountStorage = PersistentImpressionsCountStorageStub()
 
 
-                let storageContainer = SplitStorageContainer(splitDatabase: TestingHelper.createTestDatabase(name: "pepe"),
-                                                             fileStorage: FileStorageStub(),
-                                                             splitsStorage: SplitsStorageStub(),
-                                                             persistentSplitsStorage: PersistentSplitsStorageStub(),
-                                                             impressionsStorage: PersistentImpressionsStorageStub(),
-                                                             impressionsCountStorage: PersistentImpressionsCountStorageStub(),
-                                                             eventsStorage: PersistentEventsStorageStub(),
-                                                             telemetryStorage: telemetryProducer,
-                                                             mySegmentsStorage: MySegmentsStorageStub(),
-                                                             attributesStorage: AttributesStorageStub())
+        let storageContainer = SplitStorageContainer(splitDatabase: TestingHelper.createTestDatabase(name: "pepe"),
+                                                     fileStorage: FileStorageStub(),
+                                                     splitsStorage: SplitsStorageStub(),
+                                                     persistentSplitsStorage: PersistentSplitsStorageStub(),
+                                                     impressionsStorage: impressionsStorage,
+                                                     impressionsCountStorage: impressionsCountStorage,
+                                                     eventsStorage: PersistentEventsStorageStub(),
+                                                     telemetryStorage: telemetryProducer,
+                                                     mySegmentsStorage: MySegmentsStorageStub(),
+                                                     attributesStorage: AttributesStorageStub())
 
-                let apiFacade = SplitApiFacade.builder()
-                    .setUserKey("userKey")
-                    .setRestClient(RestClientStub())
-                    .setSplitConfig(SplitClientConfig())
-                    .setEventsManager(SplitEventsManagerStub())
-                    .setStreamingHttpClient(HttpClientMock(session: HttpSessionMock()))
-                    .build()
+        let apiFacade = SplitApiFacade.builder()
+            .setUserKey("userKey")
+            .setRestClient(RestClientStub())
+            .setSplitConfig(SplitClientConfig())
+            .setEventsManager(SplitEventsManagerStub())
+            .setStreamingHttpClient(HttpClientMock(session: HttpSessionMock()))
+            .build()
 
+        let impressionsRecorderSyncHelper = ImpressionsRecorderSyncHelper(impressionsStorage: impressionsStorage,
+                                                                          accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10))
         impressionsTracker = DefaultImpressionsTracker(splitConfig: SplitClientConfig(),
                                                        splitApiFacade: apiFacade,
                                                        storageContainer: storageContainer,
                                                        syncWorkerFactory: syncWorkerFactory,
-                                                       impressionsSyncHelper: ImpressionsRecorderSyncHelper(impressionsStorage: PersistentImpressionsStorageStub(),
-                                                                                                            accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)))
+                                                       impressionsSyncHelper: impressionsRecorderSyncHelper)
     }
 
-//    func testImpressionPush() {
-//        let impression = KeyImpression(featureName: "feature", keyName: "k1",
-//                                       treatment: "t1", label: nil, time: 1,
-//                                       changeNumber: 1)
-//
-//        for _ in 0..<5 {
-//            synchronizer.pushImpression(impression: impression)
-//        }
-//
-//
-//        ThreadUtils.delay(seconds: 1)
-//        XCTAssertEqual(1, telemetryProducer.impressions[.queued])
-//        XCTAssertEqual(4, telemetryProducer.impressions[.deduped])
-//    }
+    func testImpressionPush() {
+        let impression = createImpression()
+
+        for _ in 0..<5 {
+            impressionsTracker.push(impression)
+        }
+
+        ThreadUtils.delay(seconds: 1)
+        XCTAssertEqual(1, telemetryProducer.impressions[.queued])
+        XCTAssertEqual(4, telemetryProducer.impressions[.deduped])
+    }
+
+    func testStart() {
+        impressionsTracker.start()
+
+        XCTAssertTrue(periodicImpressionsRecorderWorker.startCalled)
+        XCTAssertTrue(periodicImpressionsCountRecorderWorker.startCalled)
+    }
+
+    func testPause() {
+        impressionsTracker.start()
+        impressionsTracker.pause()
+
+        XCTAssertTrue(periodicImpressionsRecorderWorker.pauseCalled)
+        XCTAssertTrue(periodicImpressionsCountRecorderWorker.pauseCalled)
+
+    }
+
+    func testResume() {
+        impressionsTracker.start()
+        impressionsTracker.pause()
+        impressionsTracker.resume()
+
+        XCTAssertTrue(periodicImpressionsRecorderWorker.resumeCalled)
+        XCTAssertTrue(periodicImpressionsCountRecorderWorker.resumeCalled)
+    }
+
+    func testStop() {
+        impressionsTracker.start()
+        impressionsTracker.stop()
+
+        XCTAssertTrue(periodicImpressionsRecorderWorker.stopCalled)
+        XCTAssertTrue(periodicImpressionsCountRecorderWorker.stopCalled)
+    }
+
+    func testFlush() {
+        impressionsTracker.start()
+        impressionsTracker.flush()
+
+        XCTAssertTrue(impressionsRecorderWorker.flushCalled)
+        XCTAssertTrue(impressionsCountRecorderWorker.flushCalled)
+    }
+
+    func testDestroy() {
+        impressionsTracker.start()
+        impressionsTracker.destroy()
+        XCTAssertTrue(periodicImpressionsRecorderWorker.destroyCalled)
+        XCTAssertTrue(periodicImpressionsCountRecorderWorker.destroyCalled)
+    }
+
+    private func createImpression() -> KeyImpression {
+        return KeyImpression(featureName: "feature", keyName: "k1",
+                             treatment: "t1", label: "the label", time: Date().unixTimestampInMiliseconds(),
+                             changeNumber: 1, storageId: "idFeature")
+
+    }
 
     override func tearDown() {
     }

--- a/SplitTests/Streaming/ImpressionsTrackerTest.swift
+++ b/SplitTests/Streaming/ImpressionsTrackerTest.swift
@@ -1,0 +1,78 @@
+//
+//  ImpressionsTrackerTest.swift
+//  SplitTests
+//
+//  Created by Javier Avrudsky on 13-May-2022.
+//  Copyright © 2022 Split. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Split
+
+class ImpressionsTrackerTest: XCTestCase {
+    var periodicImpressionsRecorderWorker: PeriodicRecorderWorkerStub!
+    var impressionsRecorderWorker: RecorderWorkerStub!
+    var impressionsTracker: ImpressionsTracker!
+    var syncWorkerFactory: SyncWorkerFactoryStub!
+    var telemetryProducer: TelemetryStorageStub!
+
+    override func setUp() {
+        periodicImpressionsRecorderWorker = PeriodicRecorderWorkerStub()
+        impressionsRecorderWorker = RecorderWorkerStub()
+
+        syncWorkerFactory = SyncWorkerFactoryStub()
+
+                syncWorkerFactory.periodicImpressionsRecorderWorker = periodicImpressionsRecorderWorker
+                syncWorkerFactory.impressionsRecorderWorker = impressionsRecorderWorker
+
+
+                telemetryProducer = TelemetryStorageStub()
+
+
+                let storageContainer = SplitStorageContainer(splitDatabase: TestingHelper.createTestDatabase(name: "pepe"),
+                                                             fileStorage: FileStorageStub(),
+                                                             splitsStorage: SplitsStorageStub(),
+                                                             persistentSplitsStorage: PersistentSplitsStorageStub(),
+                                                             impressionsStorage: PersistentImpressionsStorageStub(),
+                                                             impressionsCountStorage: PersistentImpressionsCountStorageStub(),
+                                                             eventsStorage: PersistentEventsStorageStub(),
+                                                             telemetryStorage: telemetryProducer,
+                                                             mySegmentsStorage: MySegmentsStorageStub(),
+                                                             attributesStorage: AttributesStorageStub())
+
+                let apiFacade = SplitApiFacade.builder()
+                    .setUserKey("userKey")
+                    .setRestClient(RestClientStub())
+                    .setSplitConfig(SplitClientConfig())
+                    .setEventsManager(SplitEventsManagerStub())
+                    .setStreamingHttpClient(HttpClientMock(session: HttpSessionMock()))
+                    .build()
+
+        impressionsTracker = DefaultImpressionsTracker(splitConfig: SplitClientConfig(),
+                                                       splitApiFacade: apiFacade,
+                                                       storageContainer: storageContainer,
+                                                       syncWorkerFactory: syncWorkerFactory,
+                                                       impressionsSyncHelper: ImpressionsRecorderSyncHelper(impressionsStorage: PersistentImpressionsStorageStub(),
+                                                                                                            accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)))
+    }
+
+//    func testImpressionPush() {
+//        let impression = KeyImpression(featureName: "feature", keyName: "k1",
+//                                       treatment: "t1", label: nil, time: 1,
+//                                       changeNumber: 1)
+//
+//        for _ in 0..<5 {
+//            synchronizer.pushImpression(impression: impression)
+//        }
+//
+//
+//        ThreadUtils.delay(seconds: 1)
+//        XCTAssertEqual(1, telemetryProducer.impressions[.queued])
+//        XCTAssertEqual(4, telemetryProducer.impressions[.deduped])
+//    }
+
+    override func tearDown() {
+    }
+}
+

--- a/SplitTests/Streaming/SynchronizerTest.swift
+++ b/SplitTests/Streaming/SynchronizerTest.swift
@@ -34,6 +34,7 @@ class SynchronizerTest: XCTestCase {
     var eventsManager: SplitEventsManagerStub!
     var telemetryProducer: TelemetryStorageStub!
     var byKeyApiFacade: ByKeyFacadeStub!
+    var impressionsTracker: ImpressionsTracker!
 
     let userKey = "CUSTOMER_KEY"
 
@@ -57,6 +58,8 @@ class SynchronizerTest: XCTestCase {
         eventsRecorderWorker = RecorderWorkerStub()
 
         syncWorkerFactory = SyncWorkerFactoryStub()
+
+        impressionsTracker = ImpressionsTrackStub()
 
         syncWorkerFactory.splitsSyncWorker = splitsSyncWorker
         syncWorkerFactory.mySegmentsSyncWorker = mySegmentsSyncWorker
@@ -95,6 +98,7 @@ class SynchronizerTest: XCTestCase {
 
         byKeyApiFacade = ByKeyFacadeStub()
 
+
         synchronizer = DefaultSynchronizer(splitConfig: config,
                                            defaultUserKey: userKey,
                                            telemetrySynchronizer: nil,
@@ -102,9 +106,7 @@ class SynchronizerTest: XCTestCase {
                                            splitApiFacade: apiFacade,
                                            splitStorageContainer: storageContainer,
                                            syncWorkerFactory: syncWorkerFactory,
-                                           impressionsSyncHelper:
-                                            ImpressionsRecorderSyncHelper(impressionsStorage: PersistentImpressionsStorageStub(),
-                                                                          accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)),
+                                           impressionsTracker: impressionsTracker,
                                            eventsSyncHelper:
                                             EventsRecorderSyncHelper(eventsStorage: PersistentEventsStorageStub(),
                                                                      accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10)),


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Extracted impressions logic from synchronizer to new component
- Updated tests