### PR TITLE
SDKS-5945: Allowing deprecated flags only when loglevel is NONE

### DIFF
--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -108,7 +108,9 @@ public class SplitClientConfig: NSObject {
             return Logger.shared.level == .debug
         }
         set {
-            Logger.shared.level = newValue ? .debug : .none
+            if Logger.shared.level == .none {
+                Logger.shared.level = newValue ? .debug : .none
+            }
         }
     }
 
@@ -122,7 +124,9 @@ public class SplitClientConfig: NSObject {
             return Logger.shared.level == .verbose
         }
         set {
-            Logger.shared.level = newValue ? .verbose : .none
+            if Logger.shared.level == .none {
+                Logger.shared.level = newValue ? .verbose : .none
+            }
         }
     }
 


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Allowing deprecated flags only when logLevel  = NONE