### PR TITLE
Alter "wait for event" facility so that it returns a result.

### DIFF
--- a/Split/Api/DefaultSplitClient.swift
+++ b/Split/Api/DefaultSplitClient.swift
@@ -57,15 +57,16 @@ public final class DefaultSplitClient: NSObject, SplitClient, TelemetrySplitClie
 
 // MARK: Events
 extension DefaultSplitClient {
-    public func on(event: SplitEvent, execute action: @escaping SplitAction) {
+    public func on(event: SplitEvent, execute action: @escaping SplitAction) -> Bool {
         if  event != .sdkReadyFromCache,
             eventsManager.eventAlreadyTriggered(event: event) {
             Logger.w("A handler was added for \(event.toString()) on the SDK, " +
                 "which has already fired and won’t be emitted again. The callback won’t be executed.")
-            return
+            return false
         }
         let task = SplitEventActionTask(action: action)
         eventsManager.register(event: event, task: task)
+        return true
     }
 }
 

--- a/Split/Api/LocalhostSplitClient.swift
+++ b/Split/Api/LocalhostSplitClient.swift
@@ -97,14 +97,13 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
         return results
     }
 
-    public func on(_ event: SplitEvent, _ task: SplitEventTask) {
-    }
-
-    public func on(event: SplitEvent, execute action: @escaping SplitAction) {
+    public func on(event: SplitEvent, execute action: @escaping SplitAction) -> Bool {
         if let eventsManager = self.eventsManager {
             let task = SplitEventActionTask(action: action)
             eventsManager.register(event: event, task: task)
+            return true
         }
+        return false
     }
 
     public func track(trafficType: String, eventType: String) -> Bool {

--- a/Split/Api/SplitClient.swift
+++ b/Split/Api/SplitClient.swift
@@ -24,8 +24,12 @@ public typealias SplitAction = () -> Void
     @objc(getTreatmentsWithConfigForSplits:attributes:)
     func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?) -> [String: SplitResult]
 
+    /// Executes the given action once the given event is triggered.
+    ///
+    /// Returns true if the action was retained to be executed later, or false if not.
+    @discardableResult
     @objc(onEvent:execute:)
-    func on(event: SplitEvent, execute action: @escaping SplitAction)
+    func on(event: SplitEvent, execute action: @escaping SplitAction) -> Bool
 
     // MARK: Track feature
     func track(trafficType: String, eventType: String) -> Bool

--- a/Split/Api/SplitClient.swift
+++ b/Split/Api/SplitClient.swift
@@ -24,6 +24,7 @@ public typealias SplitAction = () -> Void
     @objc(getTreatmentsWithConfigForSplits:attributes:)
     func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?) -> [String: SplitResult]
 
+    @objc(onEvent:execute:)
     func on(event: SplitEvent, execute action: @escaping SplitAction)
 
     // MARK: Track feature

--- a/Split/Api/SplitResult.swift
+++ b/Split/Api/SplitResult.swift
@@ -12,8 +12,13 @@ import Foundation
     @objc public var treatment: String
     @objc public var config: String?
 
-    init(treatment: String, config: String? = nil) {
+    @objc public init(treatment: String, config: String?) {
         self.treatment = treatment
         self.config = config
+    }
+
+    @objc public init(treatment: String) {
+        self.treatment = treatment
+        self.config = nil
     }
 }

--- a/SplitTests/Fake/InternalSplitClientStub.swift
+++ b/SplitTests/Fake/InternalSplitClientStub.swift
@@ -43,8 +43,8 @@ class InternalSplitClientStub: InternalSplitClient {
         return ["": SplitResult(treatment: SplitConstants.control)]
     }
     
-    func on(event: SplitEvent, execute action: @escaping SplitAction) {
-    
+    func on(event: SplitEvent, execute action: @escaping SplitAction) -> Bool {
+        return true
     }
     
     func track(trafficType: String, eventType: String) -> Bool {

--- a/SplitTests/Fake/SplitClientStub.swift
+++ b/SplitTests/Fake/SplitClientStub.swift
@@ -35,7 +35,8 @@ class SplitClientStub: SplitClient {
         return ["feature": SplitResult(treatment: SplitConstants.control)]
     }
     
-    func on(event: SplitEvent, execute action: @escaping SplitAction) {
+    func on(event: SplitEvent, execute action: @escaping SplitAction) -> Bool {
+        return true
     }
     
     func track(trafficType: String, eventType: String) -> Bool {

--- a/SplitTests/Localhost/LocalhostSplitClientTests.swift
+++ b/SplitTests/Localhost/LocalhostSplitClientTests.swift
@@ -67,4 +67,23 @@ class LocalhostSplitClientTests: XCTestCase {
         }
     }
 
+    func testDoesRetainOnEventActionsWhenClientHasAnEventsManager() {
+        let result = client.on(event: .sdkReady) {}
+        XCTAssertTrue(result)
+    }
+
+    func testDoesNotRetainOnEventActionsWhenClientHasNoEventsManager() {
+        let fileName = "localhost.splits"
+        let storage = FileStorageStub()
+        var config = YamlSplitStorageConfig()
+        config.refreshInterval = 0
+        let splitsStorage = LocalhostSplitsStorage(fileStorage: storage, config: config,
+                                              eventsManager: eventsManager, dataFolderName: "localhost", splitsFileName: fileName,
+                                                      bundle: Bundle(for: type(of: self)))
+        splitsStorage.loadLocal()
+        client = LocalhostSplitClient(key: Key(matchingKey: "thekey"), splitsStorage: splitsStorage, eventsManager: nil)
+
+        let result = client.on(event: .sdkReady) {}
+        XCTAssertFalse(result)
+    }
 }


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
In our use of this SDK, we found that we would sometimes submit an action to on(event:execute:), but the event (sdkReady) had already been triggered. There was no feedback to confirm this, so our action remained unexecuted.
I've added a return to the method so that the user can execute the action themselves if it is not retained by the SDK for later execution.

## How do we test the changes introduced in this PR?
I've added unit tests for my changes to the `LocalhostSplitClient`. I couldn't find existing tests for the `DefaultSplitClient` to add to, but can add them if preferable; please advise where the test should be added.

## Extra Notes
I've also added @objc annotations to a couple of other methods.