### PR TITLE
SDKS-6233: Atomic class fix

### DIFF
--- a/Split/Common/Utils/Atomic.swift
+++ b/Split/Common/Utils/Atomic.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 final class Atomic<T> {
-    private let queue = DispatchQueue.global()
+    private let queue = DispatchQueue(label: "split-atomic-int", target: DispatchQueue.global())
     private var currentValue: T
     init(_ value: T) {
         self.currentValue = value

--- a/Split/Common/Utils/Atomic.swift
+++ b/Split/Common/Utils/Atomic.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 final class Atomic<T> {
-    private let queue = DispatchQueue(label: "split-atomic-int", target: DispatchQueue.global())
+    private let queue = DispatchQueue(label: "split-atomic", target: DispatchQueue.global())
     private var currentValue: T
     init(_ value: T) {
         self.currentValue = value


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Fixing queue type on Atomic class. Queue was concurrent while it should be serial.