### PR TITLE
Remove URL defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Carthage/
 .build/
 Split.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
 release_type
+.swiftpm/

--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1242,6 +1242,7 @@
 		95F3F07325ACE53600084AF8 /* HttpMySegmentsFetcherStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F3F07225ACE53600084AF8 /* HttpMySegmentsFetcherStub.swift */; };
 		95F3F09525AE1F3800084AF8 /* ServiceConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F3F09425AE1F3700084AF8 /* ServiceConstants.swift */; };
 		95F8F06828170473009E09B1 /* multi_client_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 95F8F06728170473009E09B1 /* multi_client_test.json */; };
+		C5B748CC2B337EEA00DEDEEB /* InvalidServiceEndpointTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B748CB2B337EEA00DEDEEB /* InvalidServiceEndpointTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1968,6 +1969,7 @@
 		95F3F09425AE1F3700084AF8 /* ServiceConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceConstants.swift; sourceTree = "<group>"; };
 		95F3F45F29842EE6005A4844 /* modules.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = modules.modulemap; sourceTree = "<group>"; };
 		95F8F06728170473009E09B1 /* multi_client_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = multi_client_test.json; sourceTree = "<group>"; };
+		C5B748CB2B337EEA00DEDEEB /* InvalidServiceEndpointTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidServiceEndpointTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3121,6 +3123,7 @@
 				95737E0D2AD474A9007FD15C /* FlagSetsIntegrationTest.swift */,
 				596A7B722358E142004F6139 /* SplitSdkTimeoutTest.swift */,
 				596A7B70235729B5004F6139 /* DestroyTest.swift */,
+				C5B748CB2B337EEA00DEDEEB /* InvalidServiceEndpointTest.swift */,
 			);
 			path = Api;
 			sourceTree = "<group>";
@@ -4066,6 +4069,7 @@
 				59C492FB216695D500F5F774 /* Murmur3HashingTest.swift in Sources */,
 				59B2043B24F568660092F2E9 /* SynchronizerStub.swift in Sources */,
 				95F3EFEC258D26ED00084AF8 /* RecorderFlusherCheckerTests.swift in Sources */,
+				C5B748CC2B337EEA00DEDEEB /* InvalidServiceEndpointTest.swift in Sources */,
 				59F65F012562FF71005FE8C9 /* EventDaoTest.swift in Sources */,
 				95715A9529DB0ED800A1B2F9 /* InitDbCipherTest.swift in Sources */,
 				9519A93A27DE318000278AEC /* ByKeyFacadeTest.swift in Sources */,

--- a/Split/Network/Endpoints/ServiceEndpoints.swift
+++ b/Split/Network/Endpoints/ServiceEndpoints.swift
@@ -16,34 +16,34 @@ import Foundation
     static let kStreamingEndpoint = "https://streaming.split.io/sse"
     static let kTelemetryEndpoint = "https://telemetry.split.io/api/v1"
 
-    private (set) var sdkEndpoint: URL
-    private (set) var eventsEndpoint: URL
-    private (set) var authServiceEndpoint: URL
-    private (set) var streamingServiceEndpoint: URL
-    private (set) var telemetryServiceEndpoint: URL
+    private (set) var sdkEndpoint: URL?
+    private (set) var eventsEndpoint: URL?
+    private (set) var authServiceEndpoint: URL?
+    private (set) var streamingServiceEndpoint: URL?
+    private (set) var telemetryServiceEndpoint: URL?
 
     var isCustomSdkEndpoint: Bool {
-        return sdkEndpoint.absoluteString != ServiceEndpoints.kSdkEndpoint
+        return sdkEndpoint?.absoluteString != ServiceEndpoints.kSdkEndpoint
     }
 
     var isCustomEventsEndpoint: Bool {
-        return eventsEndpoint.absoluteString != ServiceEndpoints.kEventsEndpoint
+        return eventsEndpoint?.absoluteString != ServiceEndpoints.kEventsEndpoint
     }
 
     var isCustomAuthServiceEndpoint: Bool {
-        return authServiceEndpoint.absoluteString != ServiceEndpoints.kAuthServiceEndpoint
+        return authServiceEndpoint?.absoluteString != ServiceEndpoints.kAuthServiceEndpoint
     }
 
     var isCustomStreamingEndpoint: Bool {
-        return streamingServiceEndpoint.absoluteString != ServiceEndpoints.kStreamingEndpoint
+        return streamingServiceEndpoint?.absoluteString != ServiceEndpoints.kStreamingEndpoint
     }
 
     var isCustomTelemetryEndpoint: Bool {
-        return telemetryServiceEndpoint.absoluteString != ServiceEndpoints.kTelemetryEndpoint
+        return telemetryServiceEndpoint?.absoluteString != ServiceEndpoints.kTelemetryEndpoint
     }
 
-    private init(sdkEndpoint: URL, eventsEndpoint: URL, authServiceEndpoint: URL,
-                 streamingServiceEndpoint: URL, telemetryServiceEndpoint: URL) {
+    private init(sdkEndpoint: URL?, eventsEndpoint: URL?, authServiceEndpoint: URL?,
+                 streamingServiceEndpoint: URL?, telemetryServiceEndpoint: URL?) {
         self.sdkEndpoint = sdkEndpoint
         self.eventsEndpoint = eventsEndpoint
         self.authServiceEndpoint = authServiceEndpoint
@@ -131,46 +131,49 @@ import Foundation
                                     telemetryServiceEndpoint: telemetryServiceUrl())
         }
 
-        private func sdkUrl() -> URL {
+        private func sdkUrl() -> URL? {
             if let url = URL(string: sdkEndpoint) {
                 return url
+            } else {
+                Logger.w("SDK URL is not valid")
+                return nil
             }
-            Logger.w("SDK URL is not valid, using default")
-            return URL(string: ServiceEndpoints.kSdkEndpoint)!
         }
 
-        private func eventsUrl() -> URL {
+        private func eventsUrl() -> URL? {
             if let url = URL(string: eventsEndpoint) {
                 return url
+            } else {
+                Logger.w("Events URL is not valid")
+                return nil
             }
-            Logger.w("Events URL is not valid, using default")
-            return URL(string: ServiceEndpoints.kEventsEndpoint)!
         }
 
-        private func authServiceUrl() -> URL {
+        private func authServiceUrl() -> URL? {
             if let url = URL(string: authServiceEndpoint) {
                 return url
+            } else {
+                Logger.w("Authentication service URL is not valid")
+                return nil
             }
-            Logger.w("Authentication service URL is not valid, using default")
-            return URL(string: ServiceEndpoints.kAuthServiceEndpoint)!
         }
 
-        private func streamingServiceUrl() -> URL {
-
+        private func streamingServiceUrl() -> URL? {
             if let url = URL(string: streamingServiceEndpoint) {
                 return url
+            } else {
+                Logger.w("Streaming URL is not valid")
+                return nil
             }
-            Logger.w("Streaming URL is not valid, using default")
-            return URL(string: ServiceEndpoints.kStreamingEndpoint)!
         }
 
-        private func telemetryServiceUrl() -> URL {
-
+        private func telemetryServiceUrl() -> URL? {
             if let url = URL(string: telemetryServiceEndpoint) {
                 return url
+            } else {
+                Logger.w("Telemetry URL is not valid")
+                return nil
             }
-            Logger.w("Telemetry URL is not valid, using default")
-            return URL(string: ServiceEndpoints.kTelemetryEndpoint)!
         }
     }
 }

--- a/Split/Network/HttpClient/HttpClient.swift
+++ b/Split/Network/HttpClient/HttpClient.swift
@@ -164,7 +164,7 @@ extension DefaultHttpClient: HttpClient {
             httpHeaders += headers
         }
 
-        let request = try self.createRequest(endpoint.url, method: endpoint.method, parameters: parameters,
+        let request = try self.createRequest(endpoint.url!, method: endpoint.method, parameters: parameters,
                                              headers: httpHeaders, body: body)
         request.send()
         requestManager.addRequest(request)
@@ -173,7 +173,7 @@ extension DefaultHttpClient: HttpClient {
 
     func sendStreamRequest(endpoint: Endpoint, parameters: [String: Any]?,
                            headers: [String: String]?) throws -> HttpStreamRequest {
-        let request = try self.createStreamRequest(endpoint.url, parameters: parameters, headers: headers)
+        let request = try self.createStreamRequest(endpoint.url!, parameters: parameters, headers: headers)
         request.send()
         requestManager.addRequest(request)
         return request

--- a/Split/Network/HttpClient/HttpClient.swift
+++ b/Split/Network/HttpClient/HttpClient.swift
@@ -138,14 +138,14 @@ class DefaultHttpClient {
 // MARK: DefaultHttpClient - Private
 extension DefaultHttpClient {
 
-    private func createRequest(_ url: URL, method: HttpMethod = .get, parameters: HttpParameters? = nil,
+    private func createRequest(_ url: URL?, method: HttpMethod = .get, parameters: HttpParameters? = nil,
                                headers: HttpHeaders? = nil, body: Data? = nil) throws -> HttpDataRequest {
         let request = try DefaultHttpDataRequest(session: httpSession, url: url, method: method,
                                                  parameters: parameters, headers: headers, body: body)
         return request
     }
 
-    private func createStreamRequest(_ url: URL, parameters: HttpParameters? = nil,
+    private func createStreamRequest(_ url: URL?, parameters: HttpParameters? = nil,
                                      headers: HttpHeaders? = nil) throws -> HttpStreamRequest {
         let request = try DefaultHttpStreamRequest(session: httpSession, url: url,
                                                    parameters: parameters, headers: headers)
@@ -164,7 +164,7 @@ extension DefaultHttpClient: HttpClient {
             httpHeaders += headers
         }
 
-        let request = try self.createRequest(endpoint.url!, method: endpoint.method, parameters: parameters,
+        let request = try self.createRequest(endpoint.url, method: endpoint.method, parameters: parameters,
                                              headers: httpHeaders, body: body)
         request.send()
         requestManager.addRequest(request)

--- a/Split/Network/HttpClient/HttpClient.swift
+++ b/Split/Network/HttpClient/HttpClient.swift
@@ -173,7 +173,7 @@ extension DefaultHttpClient: HttpClient {
 
     func sendStreamRequest(endpoint: Endpoint, parameters: [String: Any]?,
                            headers: [String: String]?) throws -> HttpStreamRequest {
-        let request = try self.createStreamRequest(endpoint.url!, parameters: parameters, headers: headers)
+        let request = try self.createStreamRequest(endpoint.url, parameters: parameters, headers: headers)
         request.send()
         requestManager.addRequest(request)
         return request

--- a/Split/Network/HttpClient/HttpRequest.swift
+++ b/Split/Network/HttpClient/HttpRequest.swift
@@ -51,23 +51,26 @@ class BaseHttpRequest: HttpRequest {
         return task?.identifier ?? -1
     }
 
-    init(session: HttpSession, url: URL, method: HttpMethod,
+    init(session: HttpSession, url: URL?, method: HttpMethod,
          parameters: HttpParameters? = nil, headers: HttpHeaders?, body: Data? = nil) throws {
 
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-        let initialQueryItems = components?.queryItems
-        if let parameters = parameters {
-            components?.queryItems = parameters.map { key, value in
-                var parsedValue = "\(value)"
-                if let array = value as? [Any] {
-                    parsedValue = array.compactMap { "\($0)" }.joined(separator: ",")
+        var components: URLComponents?
+        if let url = url {
+            components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            let initialQueryItems = components?.queryItems
+            if let parameters = parameters {
+                components?.queryItems = parameters.map { key, value in
+                    var parsedValue = "\(value)"
+                    if let array = value as? [Any] {
+                        parsedValue = array.compactMap { "\($0)" }.joined(separator: ",")
+                    }
+                    return URLQueryItem(name: key, value: parsedValue)
                 }
-                return URLQueryItem(name: key, value: parsedValue)
             }
-        }
 
-        if let initialQueryItems = initialQueryItems {
-            components?.queryItems?.append(contentsOf: initialQueryItems)
+            if let initialQueryItems = initialQueryItems {
+                components?.queryItems?.append(contentsOf: initialQueryItems)
+            }
         }
 
         guard let finalUrl = components?.url else {

--- a/Split/Network/HttpClient/HttpStreamRequest.swift
+++ b/Split/Network/HttpClient/HttpStreamRequest.swift
@@ -29,7 +29,7 @@ class DefaultHttpStreamRequest: BaseHttpRequest, HttpStreamRequest {
     var incomingDataHandler: IncomingDataHandler?
     var closeHandler: CloseHandler?
 
-    init(session: HttpSession, url: URL, parameters: HttpParameters?, headers: HttpHeaders?) throws {
+    init(session: HttpSession, url: URL?, parameters: HttpParameters?, headers: HttpHeaders?) throws {
         try super.init(session: session, url: url, method: .get, parameters: parameters, headers: headers)
     }
 

--- a/Split/Network/RestClient/RestClient.swift
+++ b/Split/Network/RestClient/RestClient.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 protocol RestClient {
-    func isServerAvailable(_ url: URL) -> Bool
-    func isServerAvailable(path url: String) -> Bool
+    func isServerAvailable(_ url: URL?) -> Bool
+    func isServerAvailable(path url: String?) -> Bool
     func isEventsServerAvailable() -> Bool
     func isSdkServerAvailable() -> Bool
 }
@@ -101,12 +101,18 @@ class DefaultRestClient: SplitApiRestClient {
 }
 
 extension DefaultRestClient: RestClient {
-    func isServerAvailable(_ url: URL) -> Bool {
-        return self.isServerAvailable(path: url.absoluteString)
+    func isServerAvailable(_ url: URL?) -> Bool {
+        guard let urlString = url?.absoluteString else {
+            return false
+        }
+        return self.isServerAvailable(path: urlString)
     }
 
-    func isServerAvailable(path url: String) -> Bool {
-        return reachabilityChecker.isReachable(path: url)
+    func isServerAvailable(path url: String?) -> Bool {
+        guard let urlString = url else {
+            return false
+        }
+        return reachabilityChecker.isReachable(path: urlString)
     }
 
     func isEventsServerAvailable() -> Bool {

--- a/SplitTests/Fake/Network/RestClientStub.swift
+++ b/SplitTests/Fake/Network/RestClientStub.swift
@@ -45,8 +45,8 @@ class RestClientStub: SplitApiRestClient {
 }
 
 extension RestClientStub: RestClient {
-    func isServerAvailable(_ url: URL) -> Bool { return isServerAvailable }
-    func isServerAvailable(path url: String) -> Bool { return isServerAvailable }
+    func isServerAvailable(_ url: URL?) -> Bool { return isServerAvailable }
+    func isServerAvailable(path url: String?) -> Bool { return isServerAvailable }
     func isEventsServerAvailable() -> Bool { return isServerAvailable }
     func isSdkServerAvailable() -> Bool { return isServerAvailable }
 }

--- a/SplitTests/HttpClient/EndpointFactoryTest.swift
+++ b/SplitTests/HttpClient/EndpointFactoryTest.swift
@@ -41,7 +41,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testMySegmentsEndpointSlashKeyEncoding() {
@@ -55,7 +55,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testSplitChangesEndpoint() {
@@ -67,7 +67,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testRecordImpressionsEndpoint() {
@@ -79,7 +79,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testRecordEventsEndpoint() {
@@ -91,7 +91,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testTelemetryConfigEndpoint() {
@@ -103,7 +103,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testTelemetryUsageEndpoint() {
@@ -115,7 +115,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testStreamingAuthEndpoint() {
@@ -127,7 +127,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
     }
 
     func testStreamingEndpoint() {
@@ -139,7 +139,24 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kContentTypeEventStream, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
         XCTAssertEqual(kAblyClientKey, endpoint.headers[kAblySplitSdkClientKey])
-        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url!.absoluteString)
+    }
+
+    func testCanBeNil() {
+        let endpointUrl: String? = nil
+        serviceEndpoints = ServiceEndpoints.builder().set(sdkEndpoint: "").build()
+        factory = EndpointFactory(serviceEndpoints: serviceEndpoints,
+                                      apiKey: CommonValues.apiKey,
+                                      splitsQueryString: "")
+        let endpoint = factory.splitChangesEndpoint
+
+        XCTAssertEqual(HttpMethod.get, endpoint.method)
+        XCTAssertEqual(commonHeadersCount, endpoint.headers.count)
+        XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
+        XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
+        XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
+        XCTAssertNil(serviceEndpoints.sdkEndpoint)
+        XCTAssertNil(endpoint.url)
     }
 
     override func tearDown() {

--- a/SplitTests/HttpClient/EndpointFactoryTest.swift
+++ b/SplitTests/HttpClient/EndpointFactoryTest.swift
@@ -33,7 +33,7 @@ class EndpointFactoryTest: XCTestCase {
     }
 
     func testMySegmentsEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.sdkEndpoint.absoluteString)/mySegments/\(CommonValues.userKey)"
+        let endpointUrl = "\(serviceEndpoints.sdkEndpoint!.absoluteString)/mySegments/\(CommonValues.userKey)"
         let endpoint = factory.mySegmentsEndpoint(userKey: CommonValues.userKey)
 
         XCTAssertEqual(HttpMethod.get, endpoint.method)
@@ -41,13 +41,13 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testMySegmentsEndpointSlashKeyEncoding() {
         let userKey = "fake/key"
         let encodedUserKey = userKey.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
-        let endpointUrl = "\(serviceEndpoints.sdkEndpoint.absoluteString)/mySegments/\(encodedUserKey)"
+        let endpointUrl = "\(serviceEndpoints.sdkEndpoint!.absoluteString)/mySegments/\(encodedUserKey)"
         let endpoint = factory.mySegmentsEndpoint(userKey: userKey)
 
         XCTAssertEqual(HttpMethod.get, endpoint.method)
@@ -55,11 +55,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testSplitChangesEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.sdkEndpoint.absoluteString)/splitChanges"
+        let endpointUrl = "\(serviceEndpoints.sdkEndpoint!.absoluteString)/splitChanges"
         let endpoint = factory.splitChangesEndpoint
 
         XCTAssertEqual(HttpMethod.get, endpoint.method)
@@ -67,11 +67,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testRecordImpressionsEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.eventsEndpoint.absoluteString)/testImpressions/bulk"
+        let endpointUrl = "\(serviceEndpoints.eventsEndpoint!.absoluteString)/testImpressions/bulk"
         let endpoint = factory.impressionsEndpoint
 
         XCTAssertEqual(HttpMethod.post, endpoint.method)
@@ -79,11 +79,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testRecordEventsEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.eventsEndpoint.absoluteString)/events/bulk"
+        let endpointUrl = "\(serviceEndpoints.eventsEndpoint!.absoluteString)/events/bulk"
         let endpoint = factory.eventsEndpoint
 
         XCTAssertEqual(HttpMethod.post, endpoint.method)
@@ -91,11 +91,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testTelemetryConfigEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.telemetryServiceEndpoint.absoluteString)/metrics/config"
+        let endpointUrl = "\(serviceEndpoints.telemetryServiceEndpoint!.absoluteString)/metrics/config"
         let endpoint = factory.telemetryConfigEndpoint
 
         XCTAssertEqual(HttpMethod.post, endpoint.method)
@@ -103,11 +103,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testTelemetryUsageEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.telemetryServiceEndpoint.absoluteString)/metrics/usage"
+        let endpointUrl = "\(serviceEndpoints.telemetryServiceEndpoint!.absoluteString)/metrics/usage"
         let endpoint = factory.telemetryUsageEndpoint
 
         XCTAssertEqual(HttpMethod.post, endpoint.method)
@@ -115,11 +115,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testStreamingAuthEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.authServiceEndpoint.absoluteString)/auth"
+        let endpointUrl = "\(serviceEndpoints.authServiceEndpoint!.absoluteString)/auth"
         let endpoint = factory.sseAuthenticationEndpoint
 
         XCTAssertEqual(HttpMethod.get, endpoint.method)
@@ -127,11 +127,11 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kAuthorizationBearer, endpoint.headers[kAuthorizationHeader])
         XCTAssertEqual(kContentTypeJson, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     func testStreamingEndpoint() {
-        let endpointUrl = "\(serviceEndpoints.streamingServiceEndpoint.absoluteString)"
+        let endpointUrl = "\(serviceEndpoints.streamingServiceEndpoint!.absoluteString)"
         let endpoint = factory.streamingEndpoint
 
         XCTAssertEqual(HttpMethod.get, endpoint.method)
@@ -139,7 +139,7 @@ class EndpointFactoryTest: XCTestCase {
         XCTAssertEqual(kContentTypeEventStream, endpoint.headers[kContentTypeHeader])
         XCTAssertEqual(Version.sdk, endpoint.headers[kSplitVersionHeader])
         XCTAssertEqual(kAblyClientKey, endpoint.headers[kAblySplitSdkClientKey])
-        XCTAssertEqual(endpointUrl, endpoint.url.absoluteString)
+        XCTAssertEqual(endpointUrl, endpoint.url?.absoluteString)
     }
 
     override func tearDown() {

--- a/SplitTests/HttpClient/HttpClientTest.swift
+++ b/SplitTests/HttpClient/HttpClientTest.swift
@@ -158,6 +158,31 @@ class HttpClientTest: XCTestCase {
         XCTAssertTrue(closedOk)
     }
 
+    func testEndpointWithNilUrlThrows() throws {
+        // When an error occurred errorHandler closure should be called
+        var theError: HttpError?
+        factory = EndpointFactory(serviceEndpoints: ServiceEndpoints.builder()
+            .set(sdkEndpoint: "")
+            .build(), apiKey: CommonValues.apiKey, splitsQueryString: "")
+        let expectation = XCTestExpectation(description: "complete req err")
+        do {
+            _ = try httpClient.sendRequest(endpoint: factory.splitChangesEndpoint, parameters:["since": 100])
+                .getResponse(completionHandler: { response in },
+                             errorHandler: { error in
+                                theError = error
+                                expectation.fulfill()
+                })
+        } catch {
+            theError = error as? HttpError
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+
+        XCTAssertEqual(0, httpSession.dataTaskCallCount)
+        XCTAssertEqual(0, requestManager.addRequestCallCount)
+        XCTAssertEqual("Invalid URL", theError?.message)
+    }
+
     override func tearDown() {
     }
 }

--- a/SplitTests/HttpClient/HttpClientTest.swift
+++ b/SplitTests/HttpClient/HttpClientTest.swift
@@ -159,7 +159,6 @@ class HttpClientTest: XCTestCase {
     }
 
     func testRequestToEndpointWithNilUrlThrowsInvalidURLError() throws {
-        // When an error occurred errorHandler closure should be called
         var theError: HttpError?
         factory = EndpointFactory(serviceEndpoints: ServiceEndpoints.builder()
             .set(sdkEndpoint: "")
@@ -182,7 +181,6 @@ class HttpClientTest: XCTestCase {
     }
 
     func testStreamRequestToEndpointWithNilUrlThrowsInvalidURLError() throws {
-        // When an error occurred errorHandler closure should be called
         var theError: HttpError?
         factory = EndpointFactory(serviceEndpoints: ServiceEndpoints.builder()
             .set(sdkEndpoint: "")

--- a/SplitTests/Integration/Api/DestroyTest.swift
+++ b/SplitTests/Integration/Api/DestroyTest.swift
@@ -18,7 +18,7 @@ class DestroyTests: XCTestCase {
     var impressionsHitCount = 0
     var splitChangesHitCount = 0
     var mySegmentsHitCount = 0
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     var lastChangeNumber = 1
 
     var impressions: [KeyImpression]!

--- a/SplitTests/Integration/Api/DestroyTest.swift
+++ b/SplitTests/Integration/Api/DestroyTest.swift
@@ -18,7 +18,7 @@ class DestroyTests: XCTestCase {
     var impressionsHitCount = 0
     var splitChangesHitCount = 0
     var mySegmentsHitCount = 0
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     var lastChangeNumber = 1
 
     var impressions: [KeyImpression]!

--- a/SplitTests/Integration/Api/InvalidServiceEndpointTest.swift
+++ b/SplitTests/Integration/Api/InvalidServiceEndpointTest.swift
@@ -1,0 +1,136 @@
+//
+//  InvalidServiceEndpointTest.swift
+//  SplitTests
+//
+//  Created by Gaston Thea on 20/12/2023.
+//  Copyright © 2023 Split. All rights reserved.
+//
+
+import XCTest
+@testable import Split
+
+final class InvalidServiceEndpointTest: XCTestCase {
+
+    let kNeverRefreshRate = 9999999
+
+    var trackHitCounter = 0
+    var impressionsHitCount = 0
+    var splitChangesHitCount = 0
+    var mySegmentsHitCount = 0
+    var serverUrl = ""
+    var lastChangeNumber = 1
+
+    var impressions: [KeyImpression]!
+    var events: [EventDTO]!
+    var httpClient: HttpClient!
+    var streamingBinding: TestStreamResponseBinding?
+
+    override func setUpWithError() throws {
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+                                                          streamingHandler: buildStreamingHandler())
+        httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
+    }
+    
+    
+    private func buildTestDispatcher() -> HttpClientTestDispatcher {
+
+        return { request in
+            switch request.url.absoluteString {
+            case let(urlString) where urlString.contains("splitChanges"):
+                self.splitChangesHitCount+=1
+                let since = self.lastChangeNumber
+                return TestDispatcherResponse(code: 200,
+                                      data: Data(IntegrationHelper.emptySplitChanges(since: since, till: since).utf8))
+
+            case let(urlString) where urlString.contains("mySegments"):
+                self.mySegmentsHitCount+=1
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
+
+            case let(urlString) where urlString.contains("auth"):
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.dummySseResponse().utf8))
+
+            case let(urlString) where urlString.contains("testImpressions/bulk"):
+                self.impressionsHitCount+=1
+                if let data = request.body {
+                    if let tests = try? IntegrationHelper.buildImpressionsFromJson(content: data.stringRepresentation) {
+                        for test in tests {
+                            self.impressions.append(contentsOf: test.keyImpressions)
+                        }
+                    }
+                }
+                return TestDispatcherResponse(code: 200)
+
+            case let(urlString) where urlString.contains("events/bulk"):
+                self.trackHitCounter+=1
+                if let data = request.body {
+                    if let e = try? IntegrationHelper.buildEventsFromJson(content: data.stringRepresentation) {
+                        self.events.append(contentsOf: e)
+                    }
+                }
+                return TestDispatcherResponse(code: 200)
+
+            default:
+                return TestDispatcherResponse(code: 500)
+            }
+        }
+    }
+
+    private func buildStreamingHandler() -> TestStreamResponseBindingHandler {
+        return { request in
+            self.streamingBinding = TestStreamResponseBinding.createFor(request: request, code: 200)
+            return self.streamingBinding!
+        }
+    }
+
+    func testInvalidSdkServiceEndpointResultsInTimeout() throws {
+        let apiKey = "99049fd8653247c5ea42bc3c1ae2c6a42bc3_h"
+        let matchingKey = "CUSTOMER_ID"
+        let trafficType = "account"
+        let eventType = "testEvent"
+
+        let splitConfig: SplitClientConfig = SplitClientConfig()
+        splitConfig.featuresRefreshRate = 5
+        splitConfig.segmentsRefreshRate = 5
+        splitConfig.impressionRefreshRate = 5
+        splitConfig.impressionsChunkSize = 100
+        splitConfig.eventsPushRate = 5
+        splitConfig.sdkReadyTimeOut = 5
+        splitConfig.trafficType = trafficType
+        splitConfig.eventsPerPush = 100
+        splitConfig.eventsQueueSize = 1000
+        splitConfig.impressionsMode = "DEBUG"
+        splitConfig.serviceEndpoints = ServiceEndpoints.builder()
+            .set(sdkEndpoint: serverUrl).set(eventsEndpoint: serverUrl).build()
+        
+        let key: Key = Key(matchingKey: matchingKey, bucketingKey: nil)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setTestDatabase(TestingHelper.createTestDatabase(name: "GralIntegrationTest"))
+        _ = builder.setHttpClient(httpClient)
+        let factory = builder.setApiKey(apiKey).setKey(key).setConfig(splitConfig).build()
+        
+        let client = factory?.client
+
+        let sdkReadyExpectation = XCTestExpectation(description: "SDK READY Expectation")
+
+        var timeOutFired = false
+        var sdkReadyFired = false
+        
+        client?.on(event: SplitEvent.sdkReady) {
+            sdkReadyFired = true
+            sdkReadyExpectation.fulfill()
+        }
+        
+        client?.on(event: SplitEvent.sdkReadyTimedOut) {
+            timeOutFired = true
+            sdkReadyExpectation.fulfill()
+        }
+
+        wait(for: [sdkReadyExpectation], timeout: 10)
+
+        XCTAssertFalse(sdkReadyFired)
+        XCTAssertTrue(timeOutFired)
+        XCTAssertTrue(splitChangesHitCount == 0)
+        XCTAssertTrue(mySegmentsHitCount == 0)
+    }
+}

--- a/SplitTests/Integration/Api/SplitIntegrationTest.swift
+++ b/SplitTests/Integration/Api/SplitIntegrationTest.swift
@@ -17,7 +17,7 @@ class SplitIntegrationTests: XCTestCase {
     let trafficType = "account"
     let kNeverRefreshRate = 9999999
     var splitChange: SplitChange?
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     var trackReqIndex = 0
     var impHit = [[ImpressionsTest]]()
 

--- a/SplitTests/Integration/Api/SplitIntegrationTest.swift
+++ b/SplitTests/Integration/Api/SplitIntegrationTest.swift
@@ -17,7 +17,7 @@ class SplitIntegrationTests: XCTestCase {
     let trafficType = "account"
     let kNeverRefreshRate = 9999999
     var splitChange: SplitChange?
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     var trackReqIndex = 0
     var impHit = [[ImpressionsTest]]()
 

--- a/SplitTests/Integration/Recorder/TrackTest.swift
+++ b/SplitTests/Integration/Recorder/TrackTest.swift
@@ -14,7 +14,7 @@ class TrackTest: XCTestCase {
     let kNeverRefreshRate = 9999999
     let kChangeNbInterval: Int64 = 86400
     var reqTrackIndex = 0
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
 
     var trackHits = [[EventDTO]]()
 

--- a/SplitTests/Integration/Recorder/TrackTest.swift
+++ b/SplitTests/Integration/Recorder/TrackTest.swift
@@ -14,7 +14,7 @@ class TrackTest: XCTestCase {
     let kNeverRefreshRate = 9999999
     let kChangeNbInterval: Int64 = 86400
     var reqTrackIndex = 0
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
 
     var trackHits = [[EventDTO]]()
 

--- a/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
+++ b/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
@@ -19,7 +19,7 @@ class FetchSpecificSplitsTest: XCTestCase {
     var streamingBinding: TestStreamResponseBinding?
 
     var splitChange: SplitChange?
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     var splitsRequestUrl = ""
     var lastChangeNumber = 0
     
@@ -120,8 +120,8 @@ class FetchSpecificSplitsTest: XCTestCase {
         return { request in
             switch request.url.absoluteString {
             case let(urlString) where urlString.contains("splitChanges"):
-
-                self.splitsRequestUrl = String(request.url.absoluteString.suffix(request.url.absoluteString.count - 24))
+                print("RequestURL: " + request.url.absoluteString)
+                self.splitsRequestUrl = String(request.url.absoluteString)
                 let since = self.lastChangeNumber
                 return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptySplitChanges(since: since, till: since).utf8))
 

--- a/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
+++ b/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
@@ -19,7 +19,7 @@ class FetchSpecificSplitsTest: XCTestCase {
     var streamingBinding: TestStreamResponseBinding?
 
     var splitChange: SplitChange?
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     var splitsRequestUrl = ""
     var lastChangeNumber = 0
     

--- a/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
+++ b/SplitTests/Integration/Sync/FetchSpecificSplitsTest.swift
@@ -120,7 +120,6 @@ class FetchSpecificSplitsTest: XCTestCase {
         return { request in
             switch request.url.absoluteString {
             case let(urlString) where urlString.contains("splitChanges"):
-                print("RequestURL: " + request.url.absoluteString)
                 self.splitsRequestUrl = String(request.url.absoluteString)
                 let since = self.lastChangeNumber
                 return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptySplitChanges(since: since, till: since).utf8))

--- a/SplitTests/Integration/Sync/MySegmentServerErrorTest.swift
+++ b/SplitTests/Integration/Sync/MySegmentServerErrorTest.swift
@@ -15,7 +15,7 @@ class MySegmentServerErrorTest: XCTestCase {
     let kChangeNbInterval: Int64 = 86400
     var reqSegmentsIndex = 0
     var isFirstChangesReq = true
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     var lastChangeNumber = 0
 
     let sgExp = [

--- a/SplitTests/Integration/Sync/MySegmentServerErrorTest.swift
+++ b/SplitTests/Integration/Sync/MySegmentServerErrorTest.swift
@@ -15,7 +15,7 @@ class MySegmentServerErrorTest: XCTestCase {
     let kChangeNbInterval: Int64 = 86400
     var reqSegmentsIndex = 0
     var isFirstChangesReq = true
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     var lastChangeNumber = 0
 
     let sgExp = [

--- a/SplitTests/Integration/Sync/MySegmentUpadatedTest.swift
+++ b/SplitTests/Integration/Sync/MySegmentUpadatedTest.swift
@@ -15,7 +15,7 @@ class MySegmentUpdatedTest: XCTestCase {
     let kChangeNbInterval: Int64 = 86400
     var reqSegmentsIndex = 0
     var isFirstChangesReq = true
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
 
     let sgExp = [
         XCTestExpectation(description: "upd 0"),

--- a/SplitTests/Integration/Sync/MySegmentUpadatedTest.swift
+++ b/SplitTests/Integration/Sync/MySegmentUpadatedTest.swift
@@ -15,7 +15,7 @@ class MySegmentUpdatedTest: XCTestCase {
     let kChangeNbInterval: Int64 = 86400
     var reqSegmentsIndex = 0
     var isFirstChangesReq = true
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
 
     let sgExp = [
         XCTestExpectation(description: "upd 0"),

--- a/SplitTests/Integration/Sync/SplitChangesServerErrorTest.swift
+++ b/SplitTests/Integration/Sync/SplitChangesServerErrorTest.swift
@@ -23,7 +23,7 @@ class SplitChangesServerErrorTest: XCTestCase {
         XCTestExpectation(description: "upd 3")
     ]
 
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
 
     let impExp = XCTestExpectation(description: "impressions")
 

--- a/SplitTests/Integration/Sync/SplitChangesServerErrorTest.swift
+++ b/SplitTests/Integration/Sync/SplitChangesServerErrorTest.swift
@@ -23,7 +23,7 @@ class SplitChangesServerErrorTest: XCTestCase {
         XCTestExpectation(description: "upd 3")
     ]
 
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
 
     let impExp = XCTestExpectation(description: "impressions")
 

--- a/SplitTests/Integration/Sync/SplitChangesTest.swift
+++ b/SplitTests/Integration/Sync/SplitChangesTest.swift
@@ -14,7 +14,7 @@ class SplitChangesTest: XCTestCase {
     let kNeverRefreshRate = 9999999
     let kChangeNbInterval: Int64 = 86400
     var reqChangesIndex = 0
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     let kMatchingKey = IntegrationHelper.dummyUserKey
     var factory: SplitFactory?
 

--- a/SplitTests/Integration/Sync/SplitChangesTest.swift
+++ b/SplitTests/Integration/Sync/SplitChangesTest.swift
@@ -14,7 +14,7 @@ class SplitChangesTest: XCTestCase {
     let kNeverRefreshRate = 9999999
     let kChangeNbInterval: Int64 = 86400
     var reqChangesIndex = 0
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     let kMatchingKey = IntegrationHelper.dummyUserKey
     var factory: SplitFactory?
 

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -16,7 +16,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
     var httpClient: HttpClient!
     let kChangeNbInterval: Int64 = 86400
     var reqChangesIndex = 0
-    var serverUrl = ""
+    var serverUrl = "https://split.test.ing"
     let kMatchingKey = IntegrationHelper.dummyUserKey
     var factory: SplitFactory?
     var mySegmentsHits = 0

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -16,7 +16,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
     var httpClient: HttpClient!
     let kChangeNbInterval: Int64 = 86400
     var reqChangesIndex = 0
-    var serverUrl = "https://split.test.ing"
+    var serverUrl = "https://split"
     let kMatchingKey = IntegrationHelper.dummyUserKey
     var factory: SplitFactory?
     var mySegmentsHits = 0


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?

- Invalid URLs are not replaced by default values.
- Handle case of `nil` URL.
- Requests to `nil` URLs result in `HttpError`.