### PR TITLE
make `toString()` on `SplitEvent` public

### DIFF
--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -13,7 +13,7 @@ import Foundation
     case sdkReadyFromCache
     case sdkUpdated
 
-    func toString() -> String {
+    public func toString() -> String {
         switch self {
         case .sdkReady:
             return "SDK_READY"


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?

Tiny PR to make the `toString()` method public.