### PR TITLE
SDKS-8400: Adding logic to save impressions dedup cache

### DIFF
--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 		954F9C7D2579697B00140B81 /* SplitChangeProcessorStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F9C7C2579697B00140B81 /* SplitChangeProcessorStub.swift */; };
 		9550334A282F0FF400E5330F /* ImpressionsTrackerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95503349282F0FF400E5330F /* ImpressionsTrackerTest.swift */; };
 		9551666B276A46E000FE9D55 /* TelemetrySynchronizerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9551666A276A46E000FE9D55 /* TelemetrySynchronizerTest.swift */; };
-		955423A326793AEF002278D5 /* ImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* ImpressionsObserver.swift */; };
+		955423A326793AEF002278D5 /* DefaultImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* DefaultImpressionsObserver.swift */; };
 		955423A726794C58002278D5 /* LRUCacheTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A626794C58002278D5 /* LRUCacheTest.swift */; };
 		955428D6256810D300331356 /* ImpressionDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955428D5256810D300331356 /* ImpressionDao.swift */; };
 		955428DA256810EC00331356 /* PersistentImpressionsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955428D9256810EC00331356 /* PersistentImpressionsStorage.swift */; };
@@ -518,6 +518,7 @@
 		955E12412BFE6F5500AE6D10 /* PersistentHashImpressionStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955E12402BFE6F5500AE6D10 /* PersistentHashImpressionStorageMock.swift */; };
 		955E12432BFE704400AE6D10 /* HashedImpressionsStorageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955E12422BFE704400AE6D10 /* HashedImpressionsStorageMock.swift */; };
 		955E12452BFE758F00AE6D10 /* HashedImpressionsStorageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955E12442BFE758F00AE6D10 /* HashedImpressionsStorageTest.swift */; };
+		955E124D2C010B9000AE6D10 /* ImpressionsObserverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955E124C2C010B9000AE6D10 /* ImpressionsObserverMock.swift */; };
 		9560354327D01E8300E35BC8 /* MySegmentsStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354227D01E8300E35BC8 /* MySegmentsStorage.swift */; };
 		9560354527D0F53300E35BC8 /* SynchronizedDictionarySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354427D0F53300E35BC8 /* SynchronizedDictionarySet.swift */; };
 		9560354927D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560354827D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift */; };
@@ -653,7 +654,7 @@
 		956E42FC271DCCE7008B4DB6 /* ThreadUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954F9BB125759BBE00140B81 /* ThreadUtils.swift */; };
 		956E42FD271DCCE7008B4DB6 /* Dictionary+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEEA120EA6AE10067435E /* Dictionary+JSON.swift */; };
 		956E42FE271DCCE7008B4DB6 /* EventDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE7820EA6ADF0067435E /* EventDTO.swift */; };
-		956E42FF271DCCE7008B4DB6 /* ImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* ImpressionsObserver.swift */; };
+		956E42FF271DCCE7008B4DB6 /* DefaultImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* DefaultImpressionsObserver.swift */; };
 		956E4300271DCCE7008B4DB6 /* HttpTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5932260424A516FA00496D8B /* HttpTask.swift */; };
 		956E4301271DCCE7008B4DB6 /* NotificationManagerKeeper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F4AA9A24FE93E300A1C69A /* NotificationManagerKeeper.swift */; };
 		956E4302271DCCE7008B4DB6 /* SplitBgSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95726074262F548500350CCA /* SplitBgSynchronizer.swift */; };
@@ -982,7 +983,7 @@
 		95B02D2928D0BDC20030EC8B /* KeyImpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950B743326938B5E005FD649 /* KeyImpression.swift */; };
 		95B02D2A28D0BDC20030EC8B /* Impression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE8820EA6AE00067435E /* Impression.swift */; };
 		95B02D2B28D0BDC20030EC8B /* ImpressionsConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6DEE8A20EA6AE00067435E /* ImpressionsConstants.swift */; };
-		95B02D2C28D0BDC20030EC8B /* ImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* ImpressionsObserver.swift */; };
+		95B02D2C28D0BDC20030EC8B /* DefaultImpressionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955423A226793AEF002278D5 /* DefaultImpressionsObserver.swift */; };
 		95B02D2D28D0BDC20030EC8B /* ImpressionsCountPerFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9505681326822C6A001D7B10 /* ImpressionsCountPerFeature.swift */; };
 		95B02D2E28D0BDC20030EC8B /* ImpressionsCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9505681726822DB4001D7B10 /* ImpressionsCount.swift */; };
 		95B02D2F28D0BDC20030EC8B /* ImpressionsCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9505681B26822E96001D7B10 /* ImpressionsCounter.swift */; };
@@ -1790,7 +1791,7 @@
 		954F9C7C2579697B00140B81 /* SplitChangeProcessorStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitChangeProcessorStub.swift; sourceTree = "<group>"; };
 		95503349282F0FF400E5330F /* ImpressionsTrackerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsTrackerTest.swift; sourceTree = "<group>"; };
 		9551666A276A46E000FE9D55 /* TelemetrySynchronizerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetrySynchronizerTest.swift; sourceTree = "<group>"; };
-		955423A226793AEF002278D5 /* ImpressionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsObserver.swift; sourceTree = "<group>"; };
+		955423A226793AEF002278D5 /* DefaultImpressionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImpressionsObserver.swift; sourceTree = "<group>"; };
 		955423A626794C58002278D5 /* LRUCacheTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRUCacheTest.swift; sourceTree = "<group>"; };
 		955428D5256810D300331356 /* ImpressionDao.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImpressionDao.swift; sourceTree = "<group>"; };
 		955428D9256810EC00331356 /* PersistentImpressionsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistentImpressionsStorage.swift; sourceTree = "<group>"; };
@@ -1830,6 +1831,7 @@
 		955E12402BFE6F5500AE6D10 /* PersistentHashImpressionStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentHashImpressionStorageMock.swift; sourceTree = "<group>"; };
 		955E12422BFE704400AE6D10 /* HashedImpressionsStorageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashedImpressionsStorageMock.swift; sourceTree = "<group>"; };
 		955E12442BFE758F00AE6D10 /* HashedImpressionsStorageTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HashedImpressionsStorageTest.swift; sourceTree = "<group>"; };
+		955E124C2C010B9000AE6D10 /* ImpressionsObserverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionsObserverMock.swift; sourceTree = "<group>"; };
 		9560354227D01E8300E35BC8 /* MySegmentsStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySegmentsStorage.swift; sourceTree = "<group>"; };
 		9560354427D0F53300E35BC8 /* SynchronizedDictionarySet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SynchronizedDictionarySet.swift; sourceTree = "<group>"; };
 		9560354827D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ByKeyMySegmentsStorageTests.swift; sourceTree = "<group>"; };
@@ -2303,7 +2305,7 @@
 				950B743326938B5E005FD649 /* KeyImpression.swift */,
 				3B6DEE8820EA6AE00067435E /* Impression.swift */,
 				3B6DEE8A20EA6AE00067435E /* ImpressionsConstants.swift */,
-				955423A226793AEF002278D5 /* ImpressionsObserver.swift */,
+				955423A226793AEF002278D5 /* DefaultImpressionsObserver.swift */,
 				9505681326822C6A001D7B10 /* ImpressionsCountPerFeature.swift */,
 				9505681726822DB4001D7B10 /* ImpressionsCount.swift */,
 				9505681B26822E96001D7B10 /* ImpressionsCounter.swift */,
@@ -2706,6 +2708,7 @@
 				9572BA862AC76EA800C10FC1 /* FlagSetsCacheMock.swift */,
 				955E12402BFE6F5500AE6D10 /* PersistentHashImpressionStorageMock.swift */,
 				955E12422BFE704400AE6D10 /* HashedImpressionsStorageMock.swift */,
+				955E124C2C010B9000AE6D10 /* ImpressionsObserverMock.swift */,
 				954F9AFE2570082C00140B81 /* SplitDaoStub.swift */,
 				954F9B212571605600140B81 /* MySegmentsDaoStub.swift */,
 				952E26742833FF3F0015D633 /* UniqueKeyDaoStub.swift */,
@@ -4046,7 +4049,7 @@
 				3B6DEF1A20EA6AE50067435E /* EventDTO.swift in Sources */,
 				C5977C262BF2B7EF003E293A /* GreaterThanOrEqualToSemverMatcher.swift in Sources */,
 				95122A142759410100D93F90 /* TelemetryStorage.swift in Sources */,
-				955423A326793AEF002278D5 /* ImpressionsObserver.swift in Sources */,
+				955423A326793AEF002278D5 /* DefaultImpressionsObserver.swift in Sources */,
 				9569E1CB2784C00B006FC7E5 /* TelemetryConfigHelper.swift in Sources */,
 				5932260524A516FA00496D8B /* HttpTask.swift in Sources */,
 				9594A4612BFB930C00D4E50B /* HashedImpressionEntity.swift in Sources */,
@@ -4531,6 +4534,7 @@
 				C5977C102BF28846003E293A /* BetweenSemverMatcherTest.swift in Sources */,
 				95B17FF5275EAA6F002DC9DF /* InMemoryTelemetryStorageTest.swift in Sources */,
 				95ABF511293ABDDC006ED016 /* ImpressionsStorageStub.swift in Sources */,
+				955E124D2C010B9000AE6D10 /* ImpressionsObserverMock.swift in Sources */,
 				9557C1CA2614F67700CD9B5C /* DbForTwoDifferentApiKeyTest.swift in Sources */,
 				9560354927D100A500E35BC8 /* ByKeyMySegmentsStorageTests.swift in Sources */,
 				C5977C572BF53D60003E293A /* UnsupportedMatcherIntegrationTest.swift in Sources */,
@@ -4674,7 +4678,7 @@
 				956E42FC271DCCE7008B4DB6 /* ThreadUtils.swift in Sources */,
 				956E42FD271DCCE7008B4DB6 /* Dictionary+JSON.swift in Sources */,
 				956E42FE271DCCE7008B4DB6 /* EventDTO.swift in Sources */,
-				956E42FF271DCCE7008B4DB6 /* ImpressionsObserver.swift in Sources */,
+				956E42FF271DCCE7008B4DB6 /* DefaultImpressionsObserver.swift in Sources */,
 				956E4300271DCCE7008B4DB6 /* HttpTask.swift in Sources */,
 				956E4301271DCCE7008B4DB6 /* NotificationManagerKeeper.swift in Sources */,
 				956E4302271DCCE7008B4DB6 /* SplitBgSynchronizer.swift in Sources */,
@@ -4960,7 +4964,7 @@
 				95B02D2928D0BDC20030EC8B /* KeyImpression.swift in Sources */,
 				95B02D2A28D0BDC20030EC8B /* Impression.swift in Sources */,
 				95B02D2B28D0BDC20030EC8B /* ImpressionsConstants.swift in Sources */,
-				95B02D2C28D0BDC20030EC8B /* ImpressionsObserver.swift in Sources */,
+				95B02D2C28D0BDC20030EC8B /* DefaultImpressionsObserver.swift in Sources */,
 				95B02D2D28D0BDC20030EC8B /* ImpressionsCountPerFeature.swift in Sources */,
 				95B02D2E28D0BDC20030EC8B /* ImpressionsCount.swift in Sources */,
 				95B02D2F28D0BDC20030EC8B /* ImpressionsCounter.swift in Sources */,

--- a/Split/Common/ServiceConstants.swift
+++ b/Split/Common/ServiceConstants.swift
@@ -34,6 +34,7 @@ struct ServiceConstants {
     static let retryCount = 3
     static let uniqueKeyBulkSize = 50
     static let maxUniqueKeyQueueSize = 30000
+    static let maxHashedImpressionsQueueSize = 30
     static let aes128KeyLength = 16
     static let hashedImpressionsExpiration: Int64 = 60 * 60 * 1000 * 4 // 4 hs
 

--- a/Split/Impressions/DefaultImpressionsObserver.swift
+++ b/Split/Impressions/DefaultImpressionsObserver.swift
@@ -8,7 +8,13 @@
 
 import Foundation
 
-struct ImpressionsObserver {
+protocol ImpressionsObserver {
+    func testAndSet(impression: KeyImpression) -> Int64?
+    func clear()
+    func saveHashes()
+}
+
+struct DefaultImpressionsObserver: ImpressionsObserver {
     private let storage: HashedImpressionsStorage
 
     init(storage: HashedImpressionsStorage) {
@@ -27,6 +33,10 @@ struct ImpressionsObserver {
 
     func clear() {
         storage.clear()
+    }
+
+    func saveHashes() {
+        storage.save()
     }
 }
 

--- a/Split/Initialization/SplitComponentFactory.swift
+++ b/Split/Initialization/SplitComponentFactory.swift
@@ -158,7 +158,8 @@ class SplitComponentFactory {
                                      syncWorkerFactory: try buildSyncWorkerFactory(),
                                      impressionsSyncHelper: try buildImpressionsSyncHelper(),
                                      uniqueKeyTracker: uniqueKeyTracker,
-                                     notificationHelper: notificationHelper)
+                                     notificationHelper: notificationHelper,
+                                     impressionsObserver: DefaultImpressionsObserver(storage: storageContainer.hashedImpressionsStorage))
         catalog.add(component: component)
         return component
     }

--- a/SplitTests/Fake/Storage/ImpressionsObserverMock.swift
+++ b/SplitTests/Fake/Storage/ImpressionsObserverMock.swift
@@ -1,0 +1,29 @@
+//
+//  ImpressionsObserverMock.swift
+//  SplitTests
+//
+//  Created by Javier Avrudsky on 24/05/2024.
+//  Copyright © 2024 Split. All rights reserved.
+//
+
+import Foundation
+@testable import Split
+
+class ImpressionsObserverMock: ImpressionsObserver {
+
+    var testAndSetCalled = false
+    func testAndSet(impression: KeyImpression) -> Int64? {
+        testAndSetCalled = true
+        return nil
+    }
+
+    var clearCalled = false
+    func clear() {
+        clearCalled = true
+    }
+    
+    var saveCalled = false
+    func saveHashes() {
+        saveCalled = true
+    }
+}

--- a/SplitTests/Fake/Storage/IntegrationCoreDataHelper.swift
+++ b/SplitTests/Fake/Storage/IntegrationCoreDataHelper.swift
@@ -87,17 +87,17 @@ class IntegrationCoreDataHelper  {
             if let values = info[key] as? Set<NSManagedObject> {
                 for value in values {
                     if let entityType = getEntityType(value) {
-//                        print("ObsCrud processing key: \(key)")
+                        print("ObsCrud processing key: \(key)")
                         let key = buildObsRowKey(entity: entityType, operation: key)
                         if var row = obsCrud[key] {
                             row.increaseCount()
                             if row.shouldTrigger() {
                                 row.expectation.fulfill()
                                 obsCrud.removeValue(forKey: key)
-//                                print("ObsCrud triggered for: \(key)")
+                                print("ObsCrud triggered for: \(key)")
                             } else {
                                 obsCrud[key] = row
-//                                print("ObsCrud got : \(key) -> limit, curr: [\(row.triggerCount), \(row.currentCount)]")
+                                print("ObsCrud got : \(key) -> limit, curr: [\(row.triggerCount), \(row.currentCount)]")
                             }
                         }
                     }
@@ -113,6 +113,10 @@ class IntegrationCoreDataHelper  {
 
         if let _ = entity as? MySegmentEntity {
             return .mySegment
+        }
+
+        if let _ = entity as? HashedImpressionEntity {
+            return .hashedImpression
         }
         return nil
     }

--- a/SplitTests/Fake/Storage/PersistentImpressionsCountStorageStub.swift
+++ b/SplitTests/Fake/Storage/PersistentImpressionsCountStorageStub.swift
@@ -39,7 +39,9 @@ class PersistentImpressionsCountStorageStub: PersistentImpressionsCountStorage {
         }
     }
 
+    var pushManyCalled = false
     func pushMany(counts: [ImpressionsCountPerFeature]) {
+        pushManyCalled = true
         for count in counts {
             var row = ImpressionsCountPerFeature(feature: count.feature,
                                                  timeframe: count.timeframe,

--- a/SplitTests/Fake/Storage/UniqueKeyTrackerStub.swift
+++ b/SplitTests/Fake/Storage/UniqueKeyTrackerStub.swift
@@ -19,7 +19,9 @@ class UniqueKeyTrackerStub: UniqueKeyTracker {
         trackedKeys[userKey] = features
     }
 
+    var saveAndClearCalled = false
     func saveAndClear() {
+        saveAndClearCalled = true
         savedKeys.append(trackedKeys)
         trackedKeys.removeAll()
     }

--- a/SplitTests/Helpers/TestSplitFactory.swift
+++ b/SplitTests/Helpers/TestSplitFactory.swift
@@ -130,7 +130,8 @@ class TestSplitFactory: SplitFactory {
                                                            syncWorkerFactory: syncWorkerFactory,
                                                            impressionsSyncHelper: impressionsSyncHelper,
                                                            uniqueKeyTracker: nil,
-                                                           notificationHelper: nil)
+                                                           notificationHelper: nil,
+                                                           impressionsObserver: DefaultImpressionsObserver(storage: storageContainer.hashedImpressionsStorage))
 
         let eventsSynchronizer = DefaultEventsSynchronizer(syncWorkerFactory: syncWorkerFactory,
                                                            eventsSyncHelper: eventsSyncHelper,

--- a/SplitTests/Impressions/ImpresionsObserverTest.swift
+++ b/SplitTests/Impressions/ImpresionsObserverTest.swift
@@ -16,7 +16,7 @@ class ImpressionsObserverTest: XCTestCase {
     var storage = HashedImpressionsStorageMock()
 
     func testBasicFunctionality() {
-        let observer = ImpressionsObserver(storage: storage)
+        let observer = DefaultImpressionsObserver(storage: storage)
         let impression = KeyImpression(featureName: "someKey", keyName: "someFeature", bucketingKey: nil, treatment: "on", label: "in segment all", time: Date().unixTimestamp(), changeNumber: 1234, previousTime: nil, storageId: nil)
 
 
@@ -29,7 +29,7 @@ class ImpressionsObserverTest: XCTestCase {
     }
 
     func testConcurrencyVsAccuracy() throws {
-        let observer = ImpressionsObserver(storage: storage)
+        let observer = DefaultImpressionsObserver(storage: storage)
         let impressions = SynchronizedList<KeyImpression>()
 
 
@@ -46,7 +46,15 @@ class ImpressionsObserverTest: XCTestCase {
         }
     }
 
-    func caller(observer: ImpressionsObserver, count: Int, impressions: SynchronizedList<KeyImpression> ) {
+    func testSave() throws {
+        let observer = DefaultImpressionsObserver(storage: storage)
+
+        observer.saveHashes()
+
+        XCTAssertTrue(storage.saveCalled)
+    }
+
+    func caller(observer: DefaultImpressionsObserver, count: Int, impressions: SynchronizedList<KeyImpression> ) {
 
         for _ in 0..<count {
             var impression = KeyImpression(featureName: "feature_\(Int.random(in: 1..<10))",

--- a/SplitTests/Storage/HashedImpressionsStorageTest.swift
+++ b/SplitTests/Storage/HashedImpressionsStorageTest.swift
@@ -87,7 +87,6 @@ class HashedImpressionsStorageTests: XCTestCase {
         XCTAssertEqual(count + ServiceConstants.maxHashedImpressionsQueueSize, countAfter)
     }
 
-
     private func updateTest(save: Bool) {
         hashedStorage.loadFromDb()
 

--- a/SplitTests/Storage/HashedImpressionsStorageTest.swift
+++ b/SplitTests/Storage/HashedImpressionsStorageTest.swift
@@ -71,6 +71,22 @@ class HashedImpressionsStorageTests: XCTestCase {
         XCTAssertEqual(count + sum, countAfterSave)
     }
 
+    func testSaveOnQueue() {
+        hashedStorage.loadFromDb()
+        let countBef = persistentStorage.items.count
+        for i in SplitTestHelper.createHashedImpressions(start: 30, count: ServiceConstants.maxHashedImpressionsQueueSize - 1) {
+            hashedStorage.set(i.time, for: i.impressionHash)
+        }
+
+        let i = SplitTestHelper.createHashedImpressions(start: 100, count: ServiceConstants.maxHashedImpressionsQueueSize - 1)[0]
+        hashedStorage.set(i.time, for: i.impressionHash)
+
+        let countAfter = persistentStorage.items.count
+
+        XCTAssertEqual(count, countBef)
+        XCTAssertEqual(count + ServiceConstants.maxHashedImpressionsQueueSize, countAfter)
+    }
+
 
     private func updateTest(save: Bool) {
         hashedStorage.loadFromDb()

--- a/SplitTests/Streaming/ImpressionsTrackerTest.swift
+++ b/SplitTests/Streaming/ImpressionsTrackerTest.swift
@@ -24,11 +24,14 @@ class ImpressionsTrackerTest: XCTestCase {
     var uniqueKeysRecorderWorker: RecorderWorkerStub!
     var periodicUniqueKeysRecorderWorker: PeriodicRecorderWorkerStub!
     var flagSetsCache: FlagSetsCacheMock!
+    var impressionsObserver: ImpressionsObserver!
 
     var uniqueKeyTracker: UniqueKeyTrackerStub!
 
+    var notificationHelper: NotificationHelperStub!
+
     func testImpressionPushOptimized() {
-        createImpressionsTracker(impressionsMode: .optimized)
+        createImpressionsTracker(impressionsMode: .optimized, realObserver: true)
         let impression = createImpression()
 
         for _ in 0..<5 {
@@ -114,15 +117,41 @@ class ImpressionsTrackerTest: XCTestCase {
         XCTAssertTrue(periodicUniqueKeysRecorderWorker.startCalled)
     }
 
-    func testPause() {
-        createImpressionsTracker(impressionsMode: .optimized)
+    func testPauseOptimized() {
+        pauseTest(mode: .optimized)
+    }
+
+    func testPauseDebug() {
+        pauseTest(mode: .debug)
+    }
+
+    func testPauseNone() {
+        pauseTest(mode: .none)
+    }
+
+    func pauseTest(mode: ImpressionsMode) {
+        createImpressionsTracker(impressionsMode: mode)
+
+        let observer = impressionsObserver as! ImpressionsObserverMock
+
         impressionsTracker.start()
         impressionsTracker.pause()
 
-        XCTAssertTrue(periodicImpressionsRecorderWorker.pauseCalled)
-        XCTAssertTrue(periodicImpressionsCountRecorderWorker.pauseCalled)
-        XCTAssertFalse(periodicUniqueKeysRecorderWorker.pauseCalled)
+        if mode != .none {
+            XCTAssertTrue(periodicImpressionsRecorderWorker.pauseCalled)
+        }
 
+        if mode != .debug {
+            XCTAssertTrue(periodicImpressionsCountRecorderWorker.pauseCalled)
+            XCTAssertTrue(impressionsCountStorage.pushManyCalled)
+        }
+
+        if mode == .none {
+            XCTAssertTrue(periodicUniqueKeysRecorderWorker.pauseCalled)
+            XCTAssertTrue(uniqueKeyTracker.saveAndClearCalled)
+        }
+
+        XCTAssertTrue(observer.saveCalled)
     }
 
     func testResume() {
@@ -198,11 +227,13 @@ class ImpressionsTrackerTest: XCTestCase {
 
     func testDestroyOptimized() {
         createImpressionsTracker(impressionsMode: .optimized)
+        let observer = impressionsObserver as! ImpressionsObserverMock
         impressionsTracker.start()
         impressionsTracker.destroy()
         XCTAssertTrue(periodicImpressionsRecorderWorker.destroyCalled)
         XCTAssertTrue(periodicImpressionsCountRecorderWorker.destroyCalled)
         XCTAssertFalse(periodicUniqueKeysRecorderWorker.destroyCalled)
+        XCTAssertTrue(observer.saveCalled)
     }
 
     func testDestroyDebug() {
@@ -264,7 +295,8 @@ class ImpressionsTrackerTest: XCTestCase {
 
     }
 
-    private func createImpressionsTracker(impressionsMode: ImpressionsMode) {
+    private func createImpressionsTracker(impressionsMode: ImpressionsMode, 
+                                          realObserver: Bool = false) {
 
         let config = SplitClientConfig()
         config.impressionsMode = impressionsMode.rawValue
@@ -320,12 +352,18 @@ class ImpressionsTrackerTest: XCTestCase {
 
         let impressionsRecorderSyncHelper = ImpressionsRecorderSyncHelper(impressionsStorage: impressionsStorage,
                                                                           accumulator: DefaultRecorderFlushChecker(maxQueueSize: 10, maxQueueSizeInBytes: 10))
+
+        self.impressionsObserver = (realObserver ? DefaultImpressionsObserver(storage: storageContainer.hashedImpressionsStorage) : ImpressionsObserverMock())
+
+        notificationHelper = NotificationHelperStub()
         impressionsTracker = DefaultImpressionsTracker(splitConfig: config,
                                                        splitApiFacade: apiFacade,
                                                        storageContainer: storageContainer,
                                                        syncWorkerFactory: syncWorkerFactory,
                                                        impressionsSyncHelper: impressionsRecorderSyncHelper,
-        uniqueKeyTracker: uniqueKeyTracker, notificationHelper: nil)
+                                                       uniqueKeyTracker: uniqueKeyTracker,
+                                                       notificationHelper: notificationHelper,
+                                                       impressionsObserver: impressionsObserver)
     }
 }
 


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
- Updating impressions observer to save cache on db when go