### PR TITLE
Fix SwiftLint 0.57.0 errors

### DIFF
--- a/Split/Api/CertificatePinningConfig.swift
+++ b/Split/Api/CertificatePinningConfig.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public typealias CertificatePinningFailureHandler = (String)->Void
+public typealias CertificatePinningFailureHandler = (String) -> Void
 
 /// Custom error type for certificate pinning errors, conforming to LocalizedError.
 @objc

--- a/Split/Api/DefaultSplitClient.swift
+++ b/Split/Api/DefaultSplitClient.swift
@@ -245,7 +245,7 @@ extension DefaultSplitClient {
         return treatmentManager.getTreatmentsByFlagSets(flagSets: flagSets, attributes: attributes)
     }
 
-    public func getTreatmentsWithConfigByFlagSet(_ flagSet: String, 
+    public func getTreatmentsWithConfigByFlagSet(_ flagSet: String,
                                                  attributes: [String: Any]?) -> [String: SplitResult] {
         return treatmentManager.getTreatmentsWithConfigByFlagSet(flagSet: flagSet, attributes: attributes)
     }

--- a/Split/Api/FilterBuilder.swift
+++ b/Split/Api/FilterBuilder.swift
@@ -44,7 +44,7 @@ class FilterBuilder {
         }
 
         if (filterCounts[.bySet] ?? 0) > 0,
-            ((filterCounts[.byName] ?? 0) > 0 || (filterCounts[.byPrefix] ?? 0) > 0) {
+            (filterCounts[.byName] ?? 0) > 0 || (filterCounts[.byPrefix] ?? 0) > 0 {
             let message = "SDK Config: names or prefix and sets filter cannot be used at the same time."
             Logger.e(message)
         }

--- a/Split/Api/SplitCertPinningAuthenticator.swift
+++ b/Split/Api/SplitCertPinningAuthenticator.swift
@@ -12,6 +12,4 @@ typealias AuthCompletion = (URLSession.AuthChallengeDisposition, URLCredential?)
 
 class SplitCertPinningAuthenticator {
 
-
-
 }

--- a/Split/Api/SplitClientConfig.swift
+++ b/Split/Api/SplitClientConfig.swift
@@ -320,7 +320,6 @@ public class SplitClientConfig: NSObject {
     /// This is useful when using two factories with the same SDK Key to avoid having issues with the shared data
     @objc public var prefix: String?
 
-
     /// The `CertificatePinningConfig` class is used to configure certificate pinning for a given set of hosts.
     /// It holds an array of credentials, each of which represents a pin for a specific host,
     /// either in the form of a certificate name or a base64-encoded key hash.

--- a/Split/Api/SplitFilter.swift
+++ b/Split/Api/SplitFilter.swift
@@ -50,8 +50,8 @@ import Foundation
         }
     }
 
-    private (set) var values: [String]
-    private (set) var type: FilterType
+    private(set) var values: [String]
+    private(set) var type: FilterType
 
     // This constructor is not private (but intern) to allow Split Sync Config builder be agnostic when creating filters
     // Also is not public to force SDK users to use static functions "byName" and "byPrefix"

--- a/Split/Api/SyncConfig.swift
+++ b/Split/Api/SyncConfig.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 @objc public class SyncConfig: NSObject {
-    private (set) var filters: [SplitFilter]
+    private(set) var filters: [SplitFilter]
 
     init(filters: [SplitFilter]) {
         self.filters = filters

--- a/Split/Common/Utils/Cipher.swift
+++ b/Split/Common/Utils/Cipher.swift
@@ -63,8 +63,8 @@ struct DefaultCipher: Cipher {
 
         let status = cryptData.withUnsafeMutableBytes { (cryptBytes: UnsafeMutableRawBufferPointer) -> Int in
             var result: Int32 = -1
-            data.withUnsafeBytes { (dataBytes: UnsafeRawBufferPointer) -> Void in
-                key.withUnsafeBytes { (keyBytes: UnsafeRawBufferPointer) -> Void in
+            data.withUnsafeBytes { (dataBytes: UnsafeRawBufferPointer) in
+                key.withUnsafeBytes { (keyBytes: UnsafeRawBufferPointer) in
                     result = CCCrypt(CCOperation(kCCEncrypt), CCAlgorithm(kCCAlgorithmAES), options,
                                      keyBytes.baseAddress, key.count, nil, dataBytes.baseAddress,
                                      data.count, cryptBytes.baseAddress, cryptLength, &numBytesEncrypted)
@@ -92,8 +92,8 @@ struct DefaultCipher: Cipher {
 
         let status = cryptData.withUnsafeMutableBytes { (cryptBytes: UnsafeMutableRawBufferPointer) -> Int in
             var result: Int32 = -1
-            data.withUnsafeBytes { (dataBytes: UnsafeRawBufferPointer) -> Void in
-                key.withUnsafeBytes { (keyBytes: UnsafeRawBufferPointer) -> Void  in
+            data.withUnsafeBytes { (dataBytes: UnsafeRawBufferPointer) in
+                key.withUnsafeBytes { (keyBytes: UnsafeRawBufferPointer) in
                     result = CCCrypt(CCOperation(kCCDecrypt),
                                      CCAlgorithm(kCCAlgorithmAES),
                                      options, keyBytes.baseAddress, key.count, nil,

--- a/Split/Common/Utils/FileUtil.swift
+++ b/Split/Common/Utils/FileUtil.swift
@@ -32,7 +32,7 @@ struct FileUtil {
         return fileContent
     }
 
-    static func loadFileData(name: String, type fileType: String, bundle: Bundle)-> Data? {
+    static func loadFileData(name: String, type fileType: String, bundle: Bundle) -> Data? {
 
         guard let filepath = bundle.path(forResource: name, ofType: fileType) else {
             return nil

--- a/Split/Common/Utils/ThreadUtils.swift
+++ b/Split/Common/Utils/ThreadUtils.swift
@@ -61,7 +61,7 @@ protocol CancellableTask {
 
 class DefaultTask: CancellableTask {
 
-    private (set) var taskId: Int64
+    private(set) var taskId: Int64
     private(set) var isCancelled = false
     private(set) var delay: Double
     private(set) var work: Work

--- a/Split/Common/Validators/FactoryMonitor.swift
+++ b/Split/Common/Validators/FactoryMonitor.swift
@@ -10,10 +10,6 @@ import Foundation
 
 struct WeakFactory {
     private(set) weak var factory: SplitFactory?
-
-    init(factory: SplitFactory?) {
-        self.factory = factory
-    }
 }
 
 class FactoryRegistry {

--- a/Split/Engine/DefaultTreatmentManager.swift
+++ b/Split/Engine/DefaultTreatmentManager.swift
@@ -248,7 +248,7 @@ extension DefaultTreatmentManager {
                            + "Make sure to wait for SDK readiness before using this method"
     }
 
-    private func evaluateIfReady(splitName: String, 
+    private func evaluateIfReady(splitName: String,
                                  attributes: [String: Any]?,
                                  validationTag: String) throws -> EvaluationResult {
         if !isSdkReady() {

--- a/Split/FetcherEngine/Refresh/SplitBgSynchronizer.swift
+++ b/Split/FetcherEngine/Refresh/SplitBgSynchronizer.swift
@@ -137,7 +137,7 @@ struct BackgroundSyncExecutor {
     private let userKeys: [String: Int64]
     private let mySegmentsFetcher: HttpMySegmentsFetcher
 
-    init(prefix: String?, 
+    init(prefix: String?,
          apiKey: String,
          userKeys: [String: Int64],
          serviceEndpoints: ServiceEndpoints? = nil,

--- a/Split/Matchers/InSegmentMatcher.swift
+++ b/Split/Matchers/InSegmentMatcher.swift
@@ -22,7 +22,7 @@ class InSegmentMatcher: BaseMatcher, MatcherProtocol {
 
         // Match value is not used because it is matching key. My segments cache only has segments for that key cause
         // Split client is instantiated  based on it
-        if values.matchValue as? String != nil, let dataElements = data, let segmentName = dataElements.segmentName {
+        if values.matchValue is String, let dataElements = data, let segmentName = dataElements.segmentName {
             return context?.mySegmentsStorage?.getAll(forKey: values.matchingKey).contains(segmentName) ?? false
         }
         return false

--- a/Split/Matchers/Semver/LessThanOrEqualToSemverMatcher.swift
+++ b/Split/Matchers/Semver/LessThanOrEqualToSemverMatcher.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class LessThanOrEqualToSemverMatcher: BaseMatcher, MatcherProtocol {
-    
+
     var target: Semver?
 
     init(data: String?,

--- a/Split/Network/Endpoints/Endpoint.swift
+++ b/Split/Network/Endpoints/Endpoint.swift
@@ -10,9 +10,9 @@ import Foundation
 
 class Endpoint {
 
-    private (set) var url: URL
-    private (set) var method: HttpMethod
-    private (set) var headers = [String: String]()
+    private(set) var url: URL
+    private(set) var method: HttpMethod
+    private(set) var headers = [String: String]()
 
     private init(baseUrl: URL, path: String?, isPathEncoded: Bool = false, defaultQueryString: String? = nil) {
 

--- a/Split/Network/Endpoints/ServiceEndpoints.swift
+++ b/Split/Network/Endpoints/ServiceEndpoints.swift
@@ -16,11 +16,11 @@ import Foundation
     static let kStreamingEndpoint = "https://streaming.split.io/sse"
     static let kTelemetryEndpoint = "https://telemetry.split.io/api/v1"
 
-    private (set) public var sdkEndpoint: URL
-    private (set) public var eventsEndpoint: URL
-    private (set) public var authServiceEndpoint: URL
-    private (set) public var streamingServiceEndpoint: URL
-    private (set) public var telemetryServiceEndpoint: URL
+    private(set) public var sdkEndpoint: URL
+    private(set) public var eventsEndpoint: URL
+    private(set) public var authServiceEndpoint: URL
+    private(set) public var streamingServiceEndpoint: URL
+    private(set) public var telemetryServiceEndpoint: URL
 
     private var invalidEndpoints: [String]
 

--- a/Split/Network/HttpClient/HttpClient.swift
+++ b/Split/Network/HttpClient/HttpClient.swift
@@ -12,7 +12,7 @@ import Foundation
 /// This file also includes some complementary HTTP client components
 ///
 struct HttpQueue {
-    public static let `default`:String = "split-rest-queue"
+    public static let `default`: String = "split-rest-queue"
 }
 
 // MARK: HTTP codes

--- a/Split/Network/HttpClient/HttpDataRequest.swift
+++ b/Split/Network/HttpClient/HttpDataRequest.swift
@@ -18,7 +18,7 @@ protocol HttpDataRequest: HttpRequest, HttpDataReceivingRequest {
 // MARK: HttpDataRequest
 class DefaultHttpDataRequest: BaseHttpRequest, HttpDataRequest {
 
-    private (set) var data: Data?
+    private(set) var data: Data?
 
     override func notifyIncomingData(_ data: Data) {
         if self.data == nil {

--- a/Split/Network/HttpClient/HttpRequest.swift
+++ b/Split/Network/HttpClient/HttpRequest.swift
@@ -35,21 +35,21 @@ protocol HttpDataReceivingRequest {
 // MARK: BaseHttpRequest
 class BaseHttpRequest: HttpRequest {
 
-    private (set) var responseCode: Int = 1
-    private (set) var url: URL
-    private (set) var body: Data?
-    private (set) var method: HttpMethod
-    private (set) var parameters: HttpParameters?
-    private (set) var headers: HttpHeaders
-    private (set) weak var session: HttpSession?
-    private (set) var task: HttpTask?
-    private (set) var error: Error?
-    private (set) var pinnedCredentialFail: Bool = false
+    private(set) var responseCode: Int = 1
+    private(set) var url: URL
+    private(set) var body: Data?
+    private(set) var method: HttpMethod
+    private(set) var parameters: HttpParameters?
+    private(set) var headers: HttpHeaders
+    private(set) weak var session: HttpSession?
+    private(set) var task: HttpTask?
+    private(set) var error: Error?
+    private(set) var pinnedCredentialFail: Bool = false
 
     var requestQueue = DispatchQueue(label: "split-http-base-request", attributes: .concurrent)
     var completionHandler: RequestCompletionHandler?
     var errorHandler: RequestErrorHandler?
-    private (set) var urlRequest: URLRequest?
+    private(set) var urlRequest: URLRequest?
 
     var identifier: Int {
         return task?.identifier ?? -1

--- a/Split/Network/Streaming/SseNotifications.swift
+++ b/Split/Network/Streaming/SseNotifications.swift
@@ -82,7 +82,7 @@ struct IncomingNotification {
 
 /// Used to control streaming status
 struct ControlNotification: NotificationTypeField {
-    private (set) var type: NotificationType
+    private(set) var type: NotificationType
 
     enum ControlType: Decodable {
         case streamingResumed

--- a/Split/Network/Sync/ImpressionsTracker.swift
+++ b/Split/Network/Sync/ImpressionsTracker.swift
@@ -185,7 +185,7 @@ class DefaultImpressionsTracker: ImpressionsTracker {
         if !isPersistenceEnabled {
             return
         }
-        if (isOptimizedImpressionsMode() || isNoneImpressionsMode()),
+        if isOptimizedImpressionsMode() || isNoneImpressionsMode(),
            let counts = impressionsCounter?.popAll() {
             storageContainer.impressionsCountStorage.pushMany(counts: counts)
         }

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -58,7 +58,7 @@ class DefaultSynchronizer: Synchronizer {
     private let telemetrySynchronizer: TelemetrySynchronizer?
     private let telemetryProducer: TelemetryRuntimeProducer?
     private let featureFlagsSynchronizer: FeatureFlagsSynchronizer
-    
+
     // These three variables indicates what
     // endpoints are not available because
     // pinned credential validation has failed

--- a/Split/Storage/Splits/SplitsDecoder.swift
+++ b/Split/Storage/Splits/SplitsDecoder.swift
@@ -100,7 +100,7 @@ struct SplitsSerialDecoder: SplitsDecoder {
         if let name = name, let trafficType = trafficType, let status = status,
            let statusValue = Status.enumFromString(string: status),
            let killed = killed {
-            return Split(name: name, trafficType: trafficType, status: statusValue, 
+            return Split(name: name, trafficType: trafficType, status: statusValue,
                          sets: sets, json: json, killed: killed)
         }
 

--- a/Split/Storage/Splits/SplitsStorage.swift
+++ b/Split/Storage/Splits/SplitsStorage.swift
@@ -41,10 +41,10 @@ class DefaultSplitsStorage: SplitsStorage {
     private var trafficTypes: ConcurrentDictionary<String, Int>
     private let flagSetsCache: FlagSetsCache
 
-    private (set) var changeNumber: Int64 = -1
-    private (set) var updateTimestamp: Int64 = -1
-    private (set) var splitsFilterQueryString: String = ""
-    private (set) var flagsSpec: String = ""
+    private(set) var changeNumber: Int64 = -1
+    private(set) var updateTimestamp: Int64 = -1
+    private(set) var splitsFilterQueryString: String = ""
+    private(set) var flagsSpec: String = ""
 
     init(persistentSplitsStorage: PersistentSplitsStorage,
          flagSetsCache: FlagSetsCache) {


### PR DESCRIPTION
Our codebase recently started failing in CI because it could not successfully build the Split SDK. 

After further investigation, we were able to determine that the root cause is from SwiftLint errors and more specifically, SwiftLint errors when using [SwiftLint 0.57.0](https://github.com/realm/SwiftLint/releases/tag/0.57.0). GitHub recently updated their `macos-14` runner to use SwiftLint 0.57.0, see [here](https://github.com/actions/runner-images/blob/macos-14-arm64/20240922.1/images/macos/macos-14-Readme.md).

## What did you accomplish?
Fixed a handful of SwiftLint errors that have appeared in [SwiftLint 0.57.0](https://github.com/realm/SwiftLint/releases/tag/0.57.0) using the `--fix` flag. These are all whitespace related errors.

## How do we test the changes introduced in this PR?
Run `swiftlint`. Confirmed that running SwiftLint 0.56.2 and 0.57.0 resulted in 0 errors.

## Extra Notes
Once this is merged, it would be great if a new release could be deployed so that our builds can start passing in CI.