### PR TITLE
Explicit use of Int64 in HashedImpressionDao

### DIFF
--- a/Split/Storage/CoreDataHelper.swift
+++ b/Split/Storage/CoreDataHelper.swift
@@ -45,7 +45,9 @@ class CoreDataHelper {
         delete(entity: entity, predicate: NSPredicate(format: "\(field) IN %@", values))
     }
 
-    func delete(entity: CoreDataEntity, by field: String, values: [Int]) {
+    // Explicitly using Int64 to ensure a 64-bit integer on all platforms.
+    // Using Int without specifying a size defaults to Int32 on 32-bit platforms and Int64 on 64-bit platforms.
+    func delete(entity: CoreDataEntity, by field: String, values: [Int64]) {
         delete(entity: entity, predicate: NSPredicate(format: "\(field) IN %@", values))
     }
 

--- a/Split/Storage/HashedImpression/HashedImpressionDao.swift
+++ b/Split/Storage/HashedImpression/HashedImpressionDao.swift
@@ -61,7 +61,7 @@ class CoreDataHashedImpressionDao: BaseCoreDataDao, HashedImpressionDao {
                 return
             }
             self.coreDataHelper.delete(entity: .hashedImpression,
-                                       by: "impressionHash", values: hashes.map { Int($0.impressionHash) })
+                                       by: "impressionHash", values: hashes.map { Int64($0.impressionHash) })
             self.coreDataHelper.save()
         }
     }
@@ -78,7 +78,7 @@ class CoreDataHashedImpressionDao: BaseCoreDataDao, HashedImpressionDao {
                 .compactMap { return $0 as? HashedImpressionEntity }
 
             self.coreDataHelper.delete(entity: .hashedImpression, by: "impressionHash",
-                                       values: hashes.map { Int($0.impressionHash) })
+                                       values: hashes.map { Int64($0.impressionHash) })
             self.coreDataHelper.save()
         }
     }


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?

- On 32-bit platforms like watchOS, `Int` defaults to `Int32`, which can cause an overflow when converting a `UInt32` value that exceeds `Int32.max`. Explicitly using `Int64` to allow safe conversion without overflow.