### PR TITLE
[FME-4221] - Events metadata type

### DIFF
--- a/Split.xcodeproj/project.pbxproj
+++ b/Split.xcodeproj/project.pbxproj
@@ -354,6 +354,8 @@
 		59FB7C3C2203795F00ECC96A /* LocalhostSplitsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB7C3B2203795F00ECC96A /* LocalhostSplitsParser.swift */; };
 		59FB7C3E22037B9400ECC96A /* SpaceDelimitedLocalhostSplitsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FB7C3D22037B9400ECC96A /* SpaceDelimitedLocalhostSplitsParser.swift */; };
 		5B48D8172DEA2CED00351925 /* PrerequisitesMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF52DF52DE0B60300FEDAFE /* PrerequisitesMatcher.swift */; };
+		5B48D8192DF360D000351925 /* MetadataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B48D8182DF360CB00351925 /* MetadataType.swift */; };
+		5B48D81A2DF360D000351925 /* MetadataType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B48D8182DF360CB00351925 /* MetadataType.swift */; };
 		5B91B8392DDE4A3B000510F0 /* SplitDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B91B8382DDE4A30000510F0 /* SplitDTOTests.swift */; };
 		5BF52DF72DE0B60700FEDAFE /* PrerequisitesMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF52DF52DE0B60300FEDAFE /* PrerequisitesMatcher.swift */; };
 		5BF52DF92DE4B8D400FEDAFE /* PrerequisitesMatcherTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF52DF82DE4B8CA00FEDAFE /* PrerequisitesMatcherTest.swift */; };
@@ -1557,6 +1559,7 @@
 		59FB7C34220329B900ECC96A /* SplitFactoryBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitFactoryBuilderTests.swift; sourceTree = "<group>"; };
 		59FB7C3B2203795F00ECC96A /* LocalhostSplitsParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalhostSplitsParser.swift; sourceTree = "<group>"; };
 		59FB7C3D22037B9400ECC96A /* SpaceDelimitedLocalhostSplitsParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceDelimitedLocalhostSplitsParser.swift; sourceTree = "<group>"; };
+		5B48D8182DF360CB00351925 /* MetadataType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataType.swift; sourceTree = "<group>"; };
 		5B91B8382DDE4A30000510F0 /* SplitDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitDTOTests.swift; sourceTree = "<group>"; };
 		5BF52DF52DE0B60300FEDAFE /* PrerequisitesMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrerequisitesMatcher.swift; sourceTree = "<group>"; };
 		5BF52DF82DE4B8CA00FEDAFE /* PrerequisitesMatcherTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrerequisitesMatcherTest.swift; sourceTree = "<group>"; };
@@ -2408,6 +2411,7 @@
 		3B6DEEBE20EA6AE20067435E /* Events */ = {
 			isa = PBXGroup;
 			children = (
+				5B48D8182DF360CB00351925 /* MetadataType.swift */,
 				3B6DEEC420EA6AE20067435E /* SplitEvent.swift */,
 				3B6DEEC520EA6AE20067435E /* SplitEventsManager.swift */,
 				9530FD7927F24306005027AA /* EventsManagerCoordinator.swift */,
@@ -4285,6 +4289,7 @@
 				598EDE84224CE2C4005D4762 /* SplitResult.swift in Sources */,
 				3B6DEF4120EA6AE50067435E /* DependencyMatcherData.swift in Sources */,
 				595AD24B24E30C0C00A7B750 /* Base64Utils.swift in Sources */,
+				5B48D8192DF360D000351925 /* MetadataType.swift in Sources */,
 				3B6DEF4520EA6AE50067435E /* Matcher.swift in Sources */,
 				59FB7C0D21F6099500ECC96A /* EventValidator.swift in Sources */,
 				95B341B026136B42002F57F6 /* KeyValueStorage.swift in Sources */,
@@ -5027,6 +5032,7 @@
 				95B02D5F28D0BDC20030EC8B /* LessThanOrEqualToMatcher.swift in Sources */,
 				95B02D6028D0BDC20030EC8B /* MatchesStringMatcher.swift in Sources */,
 				952FA1312A31DCE400264AB5 /* SplitComponentCatalog.swift in Sources */,
+				5B48D81A2DF360D000351925 /* MetadataType.swift in Sources */,
 				95B02D6128D0BDC20030EC8B /* PartOfSetMatcher.swift in Sources */,
 				95B02D6228D0BDC20030EC8B /* StartWithMatcher.swift in Sources */,
 				95880CFB2AEFF177000498A0 /* FlagSetsValidator.swift in Sources */,

--- a/Split/Events/MetadataType.swift
+++ b/Split/Events/MetadataType.swift
@@ -1,0 +1,24 @@
+//  Created by Martin Cardozo on 06/06/2025
+
+@objc enum MetadataType: Int {
+    case FLAG_UPDATED
+    case FLAG_KILLED
+    case SEGMENT_UPDATED
+    case LARGE_SEGMENT_UPDATED
+    case RULE_BASED_SEGMENT_UPDATED
+    
+    public func toString() -> String {
+        switch self {
+            case .FLAG_UPDATED:
+                return "FLAG_UPDATED"
+            case .FLAG_KILLED:
+                return "FLAG_KILLED"
+            case .SEGMENT_UPDATED:
+                return "SEGMENT_UPDATED"
+            case .LARGE_SEGMENT_UPDATED:
+                return "LARGE_SEGMENT_UPDATED"
+            case .RULE_BASED_SEGMENT_UPDATED:
+                return "RULE_BASED_SEGMENT_UPDATED"
+        }
+    }
+}


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
New MetadataType
In this case I'm starting to use the new discussed naming convention, where we omit "Split" when not necessary for internal stuff

## How do we test the changes introduced in this PR?

## Extra Notes