### PR TITLE
[FME-4222] Events - New Events and InternalEvents with metadata

### DIFF
--- a/Split/Api/DefaultSplitClient.swift
+++ b/Split/Api/DefaultSplitClient.swift
@@ -89,14 +89,23 @@ extension DefaultSplitClient {
         on(event: event, executeTask: task)
     }
 
-    private func on(event: SplitEvent, executeTask task: SplitEventTask) {
-        if  event != .sdkReadyFromCache,
-            eventsManager.eventAlreadyTriggered(event: event) {
-            Logger.w("A handler was added for \(event.toString()) on the SDK, " +
-                     "which has already fired and won’t be emitted again. The callback won’t be executed.")
+    private func onWithMetadata(event: SplitEventWithMetadata, runInBackground: Bool, queue: DispatchQueue?, execute actionWithMetadata: @escaping SplitActionWithMetadata) {
+        guard let factory = clientManager?.splitFactory else { return }
+        let task = SplitEventActionTask(action: actionWithMetadata, event: event.type, runInBackground: runInBackground, factory: factory, queue: queue)
+        on(event: event.type, executeTask: task)
+    }
+
+    public func on(event: SplitEvent, executeWithMetadata action: SplitActionWithMetadata?) {
+        guard let action = action else { return }
+        onWithMetadata(event: SplitEventWithMetadata(type: event, metadata: nil), runInBackground: true, queue: nil, execute: action)
+    }
+
+    private func on(event: SplitEvent, executeTask task: SplitEventActionTask) {
+        if  event != .sdkReadyFromCache, eventsManager.eventAlreadyTriggered(event: event) {
+            Logger.w("A handler was added for \(event.toString()) on the SDK, which has already fired and won’t be emitted again. The callback won’t be executed.")
             return
         }
-        eventsManager.register(event: event, task: task)
+        eventsManager.register(event: SplitEventWithMetadata(type: event, metadata: nil), task: task)
     }
 }
 

--- a/Split/Api/DefaultSplitClient.swift
+++ b/Split/Api/DefaultSplitClient.swift
@@ -1,11 +1,5 @@
-//
-//  DefaultSplitClient.swift
-//  Split
-//
 //  Created by Brian Sztamfater on 20/9/17.
 //  Modified by Natalia Stele on 11/10/17.
-//
-//
 
 import Foundation
 
@@ -55,7 +49,7 @@ public final class DefaultSplitClient: NSObject, SplitClient, TelemetrySplitClie
     }
 }
 
-// MARK: Events
+// MARK: Customers Listeners
 extension DefaultSplitClient {
 
     public func on(event: SplitEvent, execute action: @escaping SplitAction) {
@@ -173,7 +167,7 @@ extension DefaultSplitClient {
     }
 }
 
-// MARK: Track Events
+// MARK: Tracking
 extension DefaultSplitClient {
 
     public func track(trafficType: String, eventType: String) -> Bool {
@@ -223,7 +217,7 @@ extension DefaultSplitClient {
     }
 }
 
-// MARK: Persistent attributes feature
+// MARK: Persistence
 extension DefaultSplitClient {
 
     public func setAttribute(name: String, value: Any) -> Bool {
@@ -265,8 +259,7 @@ extension DefaultSplitClient {
     }
 
     private func isValidAttribute(_ value: Any) -> Bool {
-        return anyValueValidator.isPrimitiveValue(value: value) ||
-        anyValueValidator.isList(value: value)
+        return anyValueValidator.isPrimitiveValue(value: value) || anyValueValidator.isList(value: value)
     }
 
     private func logInvalidAttribute(name: String) {
@@ -275,31 +268,31 @@ extension DefaultSplitClient {
     }
 
     private func attributesStorage() -> AttributesStorage {
-        return storageContainer.attributesStorage
+        storageContainer.attributesStorage
     }
 }
 
-// MARK: By Sets evaluation
+// MARK: By Flagsets
 extension DefaultSplitClient {
     public func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: String] {
-        return treatmentManager.getTreatmentsByFlagSet(flagSet: flagSet, attributes: attributes, evaluationOptions: nil)
+        treatmentManager.getTreatmentsByFlagSet(flagSet: flagSet, attributes: attributes, evaluationOptions: nil)
     }
 
     public func getTreatmentsByFlagSets(_ flagSets: [String], attributes: [String: Any]?) -> [String: String] {
-        return treatmentManager.getTreatmentsByFlagSets(flagSets: flagSets, attributes: attributes, evaluationOptions: nil)
+        treatmentManager.getTreatmentsByFlagSets(flagSets: flagSets, attributes: attributes, evaluationOptions: nil)
     }
 
     public func getTreatmentsWithConfigByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: SplitResult] {
-        return treatmentManager.getTreatmentsWithConfigByFlagSet(flagSet: flagSet, attributes: attributes, evaluationOptions: nil)
+        treatmentManager.getTreatmentsWithConfigByFlagSet(flagSet: flagSet, attributes: attributes, evaluationOptions: nil)
     }
 
     public func getTreatmentsWithConfigByFlagSets(_ flagSets: [String],
                                                   attributes: [String: Any]?) -> [String: SplitResult] {
-        return treatmentManager.getTreatmentsWithConfigByFlagSets(flagSets: flagSets, attributes: attributes, evaluationOptions: nil)
+        treatmentManager.getTreatmentsWithConfigByFlagSets(flagSets: flagSets, attributes: attributes, evaluationOptions: nil)
     }
 }
 
-// MARK: Flush / Destroy
+// MARK: Lifecycle
 extension DefaultSplitClient {
 
     private func syncFlush() {

--- a/Split/Api/FailHelpers.swift
+++ b/Split/Api/FailHelpers.swift
@@ -64,6 +64,8 @@ class FailedClient: SplitClient {
     func on(event: SplitEvent,
             queue: DispatchQueue, execute action: @escaping SplitAction) {
     }
+    
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {}
 
     func track(trafficType: String, eventType: String) -> Bool {
         return false

--- a/Split/Api/FailHelpers.swift
+++ b/Split/Api/FailHelpers.swift
@@ -1,10 +1,5 @@
-//
-//  FailHelpers.swift
-//  Split
-//
 //  Created by Javier Avrudsky on 24-Apr-2022.
 //  Copyright © 2022 Split. All rights reserved.
-//
 
 import Foundation
 
@@ -57,42 +52,38 @@ class FailedClient: SplitClient {
     func on(event: SplitEvent, execute action: @escaping SplitAction) {
     }
 
-    func on(event: SplitEvent, runInBackground: Bool,
-            execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent,
-            queue: DispatchQueue, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction) {}
     
     func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {}
 
     func track(trafficType: String, eventType: String) -> Bool {
-        return false
+        false
     }
 
     func track(trafficType: String, eventType: String, value: Double) -> Bool {
-        return false
+        false
     }
 
     func track(eventType: String) -> Bool {
-        return false
+        false
     }
 
     func track(eventType: String, value: Double) -> Bool {
-        return false
+        false
     }
 
     func setAttribute(name: String, value: Any) -> Bool {
-        return false
+        false
     }
 
     func getAttribute(name: String) -> Any? {
-        return false
+        false
     }
 
     func setAttributes(_ values: [String: Any]) -> Bool {
-        return false
+        false
     }
 
     func getAttributes() -> [String: Any]? {
@@ -100,11 +91,11 @@ class FailedClient: SplitClient {
     }
 
     func removeAttribute(name: String) -> Bool {
-        return false
+        false
     }
 
     func clearAttributes() -> Bool {
-        return false
+        false
     }
     
     func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: String] {
@@ -139,33 +130,30 @@ class FailedClient: SplitClient {
         return [:]
     }
 
-    func setUserConsent(enabled: Bool) {
-    }
+    func setUserConsent(enabled: Bool) {}
 
-    func flush() {
-    }
+    func flush() {}
 
-    func destroy() {
-    }
+    func destroy() {}
 
     func destroy(completion: (() -> Void)?) {
         completion?()
     }
 
     func track(trafficType: String, eventType: String, properties: [String: Any]?) -> Bool {
-        return false
+        false
     }
 
     func track(trafficType: String, eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return false
+        false
     }
 
     func track(eventType: String, properties: [String: Any]?) -> Bool {
-        return false
+        false
     }
 
     func track(eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return false
+        false
     }
 }
 
@@ -175,6 +163,6 @@ class FailedManager: SplitManager {
     var splitNames: [String] = []
 
     func split(featureName: String) -> SplitView? {
-        return nil
+        nil
     }
 }

--- a/Split/Api/LocalhostSplitClient.swift
+++ b/Split/Api/LocalhostSplitClient.swift
@@ -65,27 +65,27 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
     }
 
     public func getTreatment(_ split: String, attributes: [String: Any]?) -> String {
-        return getTreatmentWithConfig(split).treatment
+        getTreatmentWithConfig(split).treatment
     }
 
     public func getTreatment(_ split: String) -> String {
-        return getTreatment(split, attributes: nil)
+        getTreatment(split, attributes: nil)
     }
     
     public func getTreatment(_ split: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> String {
-        return getTreatmentWithConfig(split, attributes: attributes, evaluationOptions: evaluationOptions).treatment
+        getTreatmentWithConfig(split, attributes: attributes, evaluationOptions: evaluationOptions).treatment
     }
 
     public func getTreatments(splits: [String], attributes: [String: Any]?) -> [String: String] {
-        return getTreatmentsWithConfig(splits: splits, attributes: nil).mapValues({ $0.treatment })
+        getTreatmentsWithConfig(splits: splits, attributes: nil).mapValues({ $0.treatment })
     }
     
     public func getTreatments(splits: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String] {
-        return getTreatmentsWithConfig(splits: splits, attributes: attributes, evaluationOptions: evaluationOptions).mapValues({ $0.treatment })
+        getTreatmentsWithConfig(splits: splits, attributes: attributes, evaluationOptions: evaluationOptions).mapValues({ $0.treatment })
     }
 
     public func getTreatmentWithConfig(_ split: String) -> SplitResult {
-        return getTreatmentWithConfig(split, attributes: nil)
+        getTreatmentWithConfig(split, attributes: nil)
     }
 
     public func getTreatmentWithConfig(_ split: String, attributes: [String: Any]?) -> SplitResult {
@@ -102,7 +102,7 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
     }
     
     public func getTreatmentWithConfig(_ split: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> SplitResult {
-        return getTreatmentWithConfig(split, attributes: attributes)
+        getTreatmentWithConfig(split, attributes: attributes)
     }
 
     public func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?) -> [String: SplitResult] {
@@ -144,11 +144,9 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
     private func on(eventWithMetadata event: SplitEventWithMetadata, runInBackground: Bool, queue: DispatchQueue?, execute action: @escaping SplitAction) {
 
         guard let factory = clientManger?.splitFactory else { return }
+        
         if let eventsManager = self.eventsManager {
-            let task = SplitEventActionTask(action: action, event: event.type,
-                                            runInBackground: runInBackground,
-                                            factory: factory,
-                                            queue: queue)
+            let task = SplitEventActionTask(action: action, event: event.type, runInBackground: runInBackground, factory: factory, queue: queue)
             eventsManager.register(event: event, task: task)
         }
     }
@@ -156,52 +154,48 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
     private func on(eventWithMetadata event: SplitEventWithMetadata, runInBackground: Bool, queue: DispatchQueue?, execute action: @escaping SplitActionWithMetadata) {
 
         guard let factory = clientManger?.splitFactory else { return }
+        
         if let eventsManager = self.eventsManager {
-            let task = SplitEventActionTask(action: action, event: event.type,
-                                            runInBackground: runInBackground,
-                                            factory: factory,
-                                            queue: queue)
+            let task = SplitEventActionTask(action: action, event: event.type, runInBackground: runInBackground, factory: factory, queue: queue)
             eventsManager.register(event: event, task: task)
         }
     }
 
     public func track(trafficType: String, eventType: String) -> Bool {
-        return true
+        true
     }
 
     public func track(trafficType: String, eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     public func track(eventType: String) -> Bool {
-        return true
+        true
     }
 
     public func track(eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     public func track(trafficType: String, eventType: String, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     public func track(trafficType: String, eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     public func track(eventType: String, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     public func track(eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
-    public func setUserConsent(enabled: Bool) {
-    }
+    public func setUserConsent(enabled: Bool) {}
 
-    public func flush() {
-    }
+    public func flush() {}
 
     public func destroy() {
         splitsStorage.destroy()
@@ -217,63 +211,61 @@ public final class LocalhostSplitClient: NSObject, SplitClient {
 extension LocalhostSplitClient {
 
     public func setAttribute(name: String, value: Any) -> Bool {
-        return true
+        true
     }
 
     public func getAttribute(name: String) -> Any? {
-        return nil
+        nil
     }
 
     public func setAttributes(_ values: [String: Any]) -> Bool {
-        return true
+        true
     }
 
     public func getAttributes() -> [String: Any]? {
-        return nil
+        nil
     }
 
     public func removeAttribute(name: String) -> Bool {
-        return true
+        true
     }
 
     public func clearAttributes() -> Bool {
-        return true
+        true
     }
 }
 
 // MARK: TreatmentBySets Feature
 extension LocalhostSplitClient {
     public func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: String] {
-        return [String: String]()
+        [String: String]()
     }
 
     public func getTreatmentsByFlagSets(_ flagSets: [String], attributes: [String: Any]?) -> [String: String] {
-        return [String: String]()
+        [String: String]()
     }
 
     public func getTreatmentsWithConfigByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: SplitResult] {
-        return [String: SplitResult]()
+        [String: SplitResult]()
     }
 
     public func getTreatmentsWithConfigByFlagSets(_ flagSets: [String], attributes: [String: Any]?) -> [String: SplitResult] {
-        return [String: SplitResult]()
+        [String: SplitResult]()
     }
 
     public func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String] {
-        return [String: String]()
+        [String: String]()
     }
 
     public func getTreatmentsByFlagSets(_ flagSets: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String] {
-        return [String: String]()
+        [String: String]()
     }
 
-    public func getTreatmentsWithConfigByFlagSet(_ flagSet: String,
-                                                 attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult] {
-        return [String: SplitResult]()
+    public func getTreatmentsWithConfigByFlagSet(_ flagSet: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult] {
+        [String: SplitResult]()
     }
 
-    public func getTreatmentsWithConfigByFlagSets(_ flagSets: [String],
-                                                  attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult] {
-        return [String: SplitResult]()
+    public func getTreatmentsWithConfigByFlagSets(_ flagSets: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult] {
+        [String: SplitResult]()
     }
 }

--- a/Split/Api/SplitClient.swift
+++ b/Split/Api/SplitClient.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-public typealias SplitAction = () -> Void
-
 @objc public protocol SplitClient {
 
     // MARK: Evaluation feature
@@ -34,6 +32,7 @@ public typealias SplitAction = () -> Void
     func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult]
 
     func on(event: SplitEvent, execute action: @escaping SplitAction)
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) -> Void
     func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction)
     func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction)
 

--- a/Split/Api/SplitClient.swift
+++ b/Split/Api/SplitClient.swift
@@ -1,20 +1,13 @@
-//
-//  SplitClient.swift
-//  Split
-//
 //  Created by Brian Sztamfater on 18/9/17.
-//
-//
 
 import Foundation
 
 @objc public protocol SplitClient {
 
-    // MARK: Evaluation feature
+    // MARK: Evaluation
     func getTreatment(_ split: String, attributes: [String: Any]?) -> String
     func getTreatment(_ split: String) -> String
-    @objc(getTreatmentsForSplits:attributes:) func getTreatments(splits: [String],
-                                                                 attributes: [String: Any]?) -> [String: String]
+    @objc(getTreatmentsForSplits:attributes:) func getTreatments(splits: [String], attributes: [String: Any]?) -> [String: String]
 
     func getTreatmentWithConfig(_ split: String) -> SplitResult
     func getTreatmentWithConfig(_ split: String, attributes: [String: Any]?) -> SplitResult
@@ -22,27 +15,27 @@ import Foundation
     @objc(getTreatmentsWithConfigForSplits:attributes:)
     func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?) -> [String: SplitResult]
     
-    // MARK: Evaluation with Properties
+    // MARK: With Properties
     func getTreatment(_ split: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> String
-    @objc(getTreatmentsForSplits:attributes:evaluationOptions:) func getTreatments(splits: [String],
-                                                                 attributes: [String: Any]?,
-                                                                 evaluationOptions: EvaluationOptions?) -> [String: String]
+    @objc(getTreatmentsForSplits:attributes:evaluationOptions:)
+    func getTreatments(splits: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String]
     func getTreatmentWithConfig(_ split: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> SplitResult
     @objc(getTreatmentsWithConfigForSplits:attributes:evaluationOptions:)
     func getTreatmentsWithConfig(splits: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult]
 
+    // MARK: Customer listeners
     func on(event: SplitEvent, execute action: @escaping SplitAction)
     func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) -> Void
     func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction)
     func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction)
 
-    // MARK: Track feature
+    // MARK: Tracking
     func track(trafficType: String, eventType: String) -> Bool
     func track(trafficType: String, eventType: String, value: Double) -> Bool
     func track(eventType: String) -> Bool
     func track(eventType: String, value: Double) -> Bool
 
-    // MARK: Persistent attributes feature
+    // MARK: Persistence
 
     /// Creates or updates the value for the given attribute
     func setAttribute(name: String, value: Any) -> Bool
@@ -62,34 +55,31 @@ import Foundation
     /// Clears all attributes stored in the SDK.
     func clearAttributes() -> Bool
 
-    // MARK: Client lifecycle
+    // MARK: Lifecycle
     func flush()
     func destroy()
     func destroy(completion: (() -> Void)?)
 
-    @objc(trackWithTrafficType:eventType:properties:) func track(trafficType: String,
-                                                                 eventType: String,
-                                                                 properties: [String: Any]?) -> Bool
+    // MARK: With Properties
+    @objc(trackWithTrafficType:eventType:properties:)
+    func track(trafficType: String, eventType: String, properties: [String: Any]?) -> Bool
 
-    @objc(trackWithTrafficType:eventType:value:properties:) func track(trafficType: String,
-                                                                       eventType: String,
-                                                                       value: Double,
-                                                                       properties: [String: Any]?) -> Bool
+    @objc(trackWithTrafficType:eventType:value:properties:)
+    func track(trafficType: String, eventType: String, value: Double, properties: [String: Any]?) -> Bool
 
-    @objc(trackWithEventType:properties:) func track(eventType: String,
-                                                     properties: [String: Any]?) -> Bool
+    @objc(trackWithEventType:properties:)
+    func track(eventType: String, properties: [String: Any]?) -> Bool
 
-    @objc(trackWithEventType:value:properties:) func track(eventType: String,
-                                                           value: Double,
-                                                           properties: [String: Any]?) -> Bool
+    @objc(trackWithEventType:value:properties:)
+    func track(eventType: String, value: Double, properties: [String: Any]?) -> Bool
 
-    // MARK: Evaluation with flagsets
+    // MARK: With Flagsets
     func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: String]
     func getTreatmentsByFlagSets(_ flagSets: [String], attributes: [String: Any]?) -> [String: String]
     func getTreatmentsWithConfigByFlagSet(_ flagSet: String, attributes: [String: Any]?) -> [String: SplitResult]
     func getTreatmentsWithConfigByFlagSets(_ flagSets: [String], attributes: [String: Any]?) -> [String: SplitResult]
     
-    // MARK: Evaluation with flagsets and properties
+    // MARK: With flagsets and properties
     func getTreatmentsByFlagSet(_ flagSet: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String]
     func getTreatmentsByFlagSets(_ flagSets: [String], attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: String]
     func getTreatmentsWithConfigByFlagSet(_ flagSet: String, attributes: [String: Any]?, evaluationOptions: EvaluationOptions?) -> [String: SplitResult]

--- a/Split/Common/Structs/BlockingQueue.swift
+++ b/Split/Common/Structs/BlockingQueue.swift
@@ -73,19 +73,23 @@ class GenericBlockingQueue<Item> {
 
 // Protocol to allow mocking
 protocol InternalEventBlockingQueue {
-    func add(_ item: SplitInternalEvent)
-    func take() throws -> SplitInternalEvent
+    func add(_ item: SplitInternalEventWithMetadata)
+    func take() throws -> SplitInternalEventWithMetadata
     func stop()
 }
 
 class DefaultInternalEventBlockingQueue: InternalEventBlockingQueue {
-    let blockingQueue = GenericBlockingQueue<SplitInternalEvent>()
+    let blockingQueue = GenericBlockingQueue<SplitInternalEventWithMetadata>()
     func add(_ item: SplitInternalEvent) {
+        blockingQueue.add(SplitInternalEventWithMetadata(item))
+    }
+
+    func add(_ item: SplitInternalEventWithMetadata) {
         blockingQueue.add(item)
     }
 
-    func take() throws -> SplitInternalEvent {
-        let value =  try blockingQueue.take()
+    func take() throws -> SplitInternalEventWithMetadata {
+        let value = try blockingQueue.take()
         return value
     }
 

--- a/Split/Engine/DefaultTreatmentManager.swift
+++ b/Split/Engine/DefaultTreatmentManager.swift
@@ -337,8 +337,8 @@ extension DefaultTreatmentManager {
     }
 
     private func isSdkReady() -> Bool {
-        return eventsManager.eventAlreadyTriggered(event: SplitEvent.sdkReadyFromCache) ||
-            eventsManager.eventAlreadyTriggered(event: SplitEvent.sdkReady)
+        return eventsManager.eventAlreadyTriggered(event: .sdkReadyFromCache) ||
+            eventsManager.eventAlreadyTriggered(event: .sdkReady)
     }
 
     private func checkAndLogIfDestroyed(logTag: String) -> Bool {

--- a/Split/Engine/Evaluator.swift
+++ b/Split/Engine/Evaluator.swift
@@ -6,49 +6,10 @@
 //
 
 import Foundation
-// swiftlint:disable function_body_length
-struct EvaluationResult {
-    var treatment: String
-    var label: String
-    var changeNumber: Int64?
-    var configuration: String?
-    var impressionsDisabled: Bool
 
-    init(treatment: String, label: String, changeNumber: Int64? = nil, configuration: String? = nil,
-         impressionsDisabled: Bool = false) {
-        self.treatment = treatment
-        self.label = label
-        self.changeNumber = changeNumber
-        self.configuration = configuration
-        self.impressionsDisabled = impressionsDisabled
-    }
-}
-
-struct EvalValues {
-    let matchValue: Any?
-    let matchingKey: String
-    let bucketingKey: String?
-    let attributes: [String: Any]?
-
-    init(matchValue: Any?, matchingKey: String, bucketingKey: String? = nil, attributes: [String: Any]? = nil) {
-        self.matchValue = matchValue
-        self.matchingKey = matchingKey
-        self.bucketingKey = bucketingKey
-        self.attributes = attributes
-    }
-}
-
-// Components needed
-struct EvalContext {
-    let evaluator: Evaluator?
-    let mySegmentsStorage: MySegmentsStorage?
-    let myLargeSegmentsStorage: MySegmentsStorage?
-    let ruleBasedSegmentsStorage: RuleBasedSegmentsStorage?
-}
 
 protocol Evaluator {
-    func evalTreatment(matchingKey: String, bucketingKey: String?,
-                       splitName: String, attributes: [String: Any]?) throws -> EvaluationResult
+    func evalTreatment(matchingKey: String, bucketingKey: String?, splitName: String, attributes: [String: Any]?) throws -> EvaluationResult
 }
 
 class DefaultEvaluator: Evaluator {
@@ -183,4 +144,43 @@ private extension Split {
     func isImpressionsDisabled() -> Bool {
         return self.impressionsDisabled ?? false
     }
+}
+
+//MARK: Components needed
+struct EvaluationResult {
+    var treatment: String
+    var label: String
+    var changeNumber: Int64?
+    var configuration: String?
+    var impressionsDisabled: Bool
+
+    init(treatment: String, label: String, changeNumber: Int64? = nil, configuration: String? = nil,
+         impressionsDisabled: Bool = false) {
+        self.treatment = treatment
+        self.label = label
+        self.changeNumber = changeNumber
+        self.configuration = configuration
+        self.impressionsDisabled = impressionsDisabled
+    }
+}
+
+struct EvalValues {
+    let matchValue: Any?
+    let matchingKey: String
+    let bucketingKey: String?
+    let attributes: [String: Any]?
+
+    init(matchValue: Any?, matchingKey: String, bucketingKey: String? = nil, attributes: [String: Any]? = nil) {
+        self.matchValue = matchValue
+        self.matchingKey = matchingKey
+        self.bucketingKey = bucketingKey
+        self.attributes = attributes
+    }
+}
+
+struct EvalContext {
+    let evaluator: Evaluator?
+    let mySegmentsStorage: MySegmentsStorage?
+    let myLargeSegmentsStorage: MySegmentsStorage?
+    let ruleBasedSegmentsStorage: RuleBasedSegmentsStorage?
 }

--- a/Split/Events/EventMetadataType.swift
+++ b/Split/Events/EventMetadataType.swift
@@ -10,10 +10,6 @@ import Foundation
         self.type = type
         self.data = data
     }
-    
-    public static func == (lhs: EventMetadata, rhs: EventMetadata) -> Bool {
-        return lhs.type == rhs.type && lhs.data == rhs.data
-    }
 }
 
 @objc enum EventMetadataType: Int {

--- a/Split/Events/EventMetadataType.swift
+++ b/Split/Events/EventMetadataType.swift
@@ -12,7 +12,7 @@ import Foundation
     }
 }
 
-@objc enum EventMetadataType: Int {
+@objc public enum EventMetadataType: Int {
     case FLAGS_UPDATED
     case FLAGS_KILLED
     case SEGMENTS_UPDATED

--- a/Split/Events/EventMetadataType.swift
+++ b/Split/Events/EventMetadataType.swift
@@ -4,9 +4,9 @@ import Foundation
 
 @objc public class EventMetadata: NSObject {
     public var type: EventMetadataType
-    public var data: String = ""
+    public var data: [String] = []
 
-    init(type: EventMetadataType, data: String) {
+    init(type: EventMetadataType, data: [String]) {
         self.type = type
         self.data = data
     }

--- a/Split/Events/EventMetadataType.swift
+++ b/Split/Events/EventMetadataType.swift
@@ -3,8 +3,8 @@
 import Foundation
 
 @objc public class EventMetadata: NSObject {
-    var type: EventMetadataType
-    var data: String = ""
+    public var type: EventMetadataType
+    public var data: String = ""
 
     init(type: EventMetadataType, data: String) {
         self.type = type

--- a/Split/Events/EventMetadataType.swift
+++ b/Split/Events/EventMetadataType.swift
@@ -10,6 +10,10 @@ import Foundation
         self.type = type
         self.data = data
     }
+    
+    public static func == (lhs: EventMetadata, rhs: EventMetadata) -> Bool {
+        return lhs.type == rhs.type && lhs.data == rhs.data
+    }
 }
 
 @objc enum EventMetadataType: Int {

--- a/Split/Events/EventsManagerCoordinator.swift
+++ b/Split/Events/EventsManagerCoordinator.swift
@@ -80,11 +80,7 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
         }
     }
 
-    func register(event: SplitEvent, task: SplitEventActionTask) {
-        // Intentionally empty
-    }
+    func register(event: SplitEvent, task: SplitEventActionTask) {}
     
-    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
-        // Intentionally empty
-    }
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {}
 }

--- a/Split/Events/EventsManagerCoordinator.swift
+++ b/Split/Events/EventsManagerCoordinator.swift
@@ -66,7 +66,7 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
             manager.start()
             managers[key] = manager
             triggered.forEach {
-                manager.notifyInternalEvent($0)
+                manager.notifyInternalEvent($0, metadata: nil)
             }
         }
     }

--- a/Split/Events/EventsManagerCoordinator.swift
+++ b/Split/Events/EventsManagerCoordinator.swift
@@ -20,8 +20,9 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
     private let queue = DispatchQueue(label: "split-event-manager-coordinator")
     private let eventsToHandle: Set<SplitInternalEvent> = Set(
         [.splitsLoadedFromCache,
-        .splitsUpdated,
-        .splitKilledNotification]
+         .splitsUpdated,
+         .splitKilledNotification,
+         .ruleBasedSegmentsUpdated]
     )
 
     func notifyInternalEvent(_ event: SplitInternalEvent) {

--- a/Split/Events/EventsManagerCoordinator.swift
+++ b/Split/Events/EventsManagerCoordinator.swift
@@ -80,6 +80,11 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
         }
     }
 
-    func register(event: SplitEvent, task: SplitEventActionTask) {}
-    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {}
+    func register(event: SplitEvent, task: SplitEventActionTask) {
+        // Intentionally empty
+    }
+    
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
+        // Intentionally empty
+    }
 }

--- a/Split/Events/EventsManagerCoordinator.swift
+++ b/Split/Events/EventsManagerCoordinator.swift
@@ -25,6 +25,10 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
     )
 
     func notifyInternalEvent(_ event: SplitInternalEvent) {
+        notifyInternalEvent(event, metadata: nil)
+    }
+
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata? = nil) {
         if !eventsToHandle.contains(event) {
             return
         }
@@ -33,7 +37,7 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
 
             self.triggered.insert(event)
             self.managers.forEach { _, manager in
-                manager.notifyInternalEvent(event)
+                manager.notifyInternalEvent(event, metadata: metadata)
             }
         }
     }
@@ -76,5 +80,6 @@ class MainSplitEventsManager: SplitEventsManagerCoordinator {
         }
     }
 
-    func register(event: SplitEvent, task: SplitEventTask) {}
+    func register(event: SplitEvent, task: SplitEventActionTask) {}
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {}
 }

--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -13,14 +13,6 @@ import Foundation
         self.type = type
         self.metadata = metadata
     }
-    
-    public static func == (lhs: SplitEventWithMetadata, rhs: SplitEventWithMetadata) -> Bool {
-        return lhs.type == rhs.type && lhs.metadata == rhs.metadata
-    }
-    
-    func isSameType(_ other: SplitEventWithMetadata) -> Bool {
-        return self.type == other.type
-    }
 }
 
 @objc public enum SplitEvent: Int {

--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -13,6 +13,14 @@ import Foundation
         self.type = type
         self.metadata = metadata
     }
+    
+    public static func == (lhs: SplitEventWithMetadata, rhs: SplitEventWithMetadata) -> Bool {
+        return lhs.type == rhs.type && lhs.metadata == rhs.metadata
+    }
+    
+    func isSameType(_ other: SplitEventWithMetadata) -> Bool {
+        return self.type == other.type
+    }
 }
 
 @objc public enum SplitEvent: Int {

--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -1,17 +1,31 @@
-//
-//  SplitEvent.swift
-//  Split
-//
 //  Created by Sebastian Arrubia on 4/17/18.
-//
 
 import Foundation
+
+// All events (internal & external) support metadata.
+// Internal errors are propagated to the customer as events "(.sdkError)". The error info will travel as the event metadata.
+
+@objcMembers public class SplitEventWithMetadata: NSObject {
+    let type: SplitEvent
+    let metadata: EventMetadata?
+
+    @objc public init(type: SplitEvent, metadata: EventMetadata? = nil) {
+        self.type = type
+        self.metadata = metadata
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SplitEventWithMetadata else { return false }
+        return self.type == other.type
+    }
+}
 
 @objc public enum SplitEvent: Int {
     case sdkReady
     case sdkReadyTimedOut
     case sdkReadyFromCache
     case sdkUpdated
+    case sdkError
 
     public func toString() -> String {
         switch self {
@@ -23,6 +37,8 @@ import Foundation
             return "SDK_READY_TIMED_OUT"
         case .sdkReadyFromCache:
             return "SDK_READY_FROM_CACHE"
+        case .sdkError:
+            return "SDK_ERROR"
         }
     }
 }

--- a/Split/Events/SplitEvent.swift
+++ b/Split/Events/SplitEvent.swift
@@ -13,11 +13,6 @@ import Foundation
         self.type = type
         self.metadata = metadata
     }
-
-    public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? SplitEventWithMetadata else { return false }
-        return self.type == other.type
-    }
 }
 
 @objc public enum SplitEvent: Int {

--- a/Split/Events/SplitEventActionTask.swift
+++ b/Split/Events/SplitEventActionTask.swift
@@ -1,16 +1,17 @@
-//
-//  SplitEventActionTask.swift
-//  Split
-//
 //  Created by Javier L. Avrudsky on 7/6/18.
-//
 
 import Foundation
 
+public typealias SplitAction = () -> Void
+public typealias SplitActionWithMetadata = (_ metadata: EventMetadata?) -> Void
+
 class SplitEventActionTask: SplitEventTask {
 
+    // Private
     private var eventHandler: SplitAction?
+    private var eventHandlerWithMetadata: SplitActionWithMetadata?
     private var queue: DispatchQueue?
+    
     var event: SplitEvent
     var runInBackground: Bool = false
     var factory: SplitFactory
@@ -27,13 +28,25 @@ class SplitEventActionTask: SplitEventTask {
         self.queue = queue
         self.factory = factory
     }
+    
+    init(action: @escaping SplitActionWithMetadata, event: SplitEvent, runInBackground: Bool = false, factory: SplitFactory, queue: DispatchQueue? = nil) {
+        self.eventHandlerWithMetadata = action
+        self.event = event
+        self.runInBackground = runInBackground
+        self.queue = queue
+        self.factory = factory
+    }
 
     func takeQueue() -> DispatchQueue? {
         defer { queue = nil }
         return queue
     }
-
-    func run() {
+    
+    func run(_ metadata: EventMetadata?) {
         eventHandler?()
+        
+        if let metadata = metadata {
+            eventHandlerWithMetadata?(metadata)
+        }
     }
 }

--- a/Split/Events/SplitEventTask.swift
+++ b/Split/Events/SplitEventTask.swift
@@ -11,5 +11,5 @@ protocol SplitEventTask {
     var event: SplitEvent { get }
     var runInBackground: Bool { get }
     func takeQueue() -> DispatchQueue?
-    func run()
+    func run(_ metadata: EventMetadata?)
 }

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -51,6 +51,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         }
     }
     
+    // MARK: Notifiers
     func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata? = nil) {
         let event = SplitInternalEventWithMetadata(event, metadata: metadata)
 
@@ -64,7 +65,8 @@ class DefaultSplitEventsManager: SplitEventsManager {
     func notifyInternalEvent(_ event: SplitInternalEvent) {
         notifyInternalEvent(event, metadata: nil)
     }
-
+    
+    // MARK: Registers
     func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
         let eventName = event.type.toString()
         processQueue.async { [weak self] in
@@ -83,6 +85,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         register(event: SplitEventWithMetadata(type: event, metadata: nil), task: task)
     }
 
+    // MARK: Flow
     func start() {
         dataAccessQueue.sync {
             if self.isStarted {
@@ -158,31 +161,31 @@ class DefaultSplitEventsManager: SplitEventsManager {
             }
             self.triggered.append(event.type)
             switch event.type {
-            case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
-                if isTriggered(external: .sdkReady) {
-                    trigger(event: .sdkUpdated, metadata: event.metadata)
-                    continue
-                }
-                self.triggerSdkReadyIfNeeded()
+                case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
+                    if isTriggered(external: .sdkReady) {
+                        trigger(event: .sdkUpdated, metadata: event.metadata)
+                        continue
+                    }
+                    self.triggerSdkReadyIfNeeded()
 
-            case .mySegmentsLoadedFromCache, .myLargeSegmentsLoadedFromCache,
-                    .splitsLoadedFromCache, .attributesLoadedFromCache:
-                Logger.v("Event \(event) triggered")
-                if isTriggered(internal: .splitsLoadedFromCache),
-                   isTriggered(internal: .mySegmentsLoadedFromCache),
-                   isTriggered(internal: .myLargeSegmentsLoadedFromCache),
-                   isTriggered(internal: .attributesLoadedFromCache) {
-                    trigger(event: .sdkReadyFromCache)
-                }
-            case .splitKilledNotification:
-                if isTriggered(external: .sdkReady) {
-                    trigger(event: .sdkUpdated, metadata: event.metadata)
-                    continue
-                }
-            case .sdkReadyTimeoutReached:
-                if !isTriggered(external: .sdkReady) {
-                    trigger(event: .sdkReadyTimedOut)
-                }
+                case .mySegmentsLoadedFromCache, .myLargeSegmentsLoadedFromCache,
+                        .splitsLoadedFromCache, .attributesLoadedFromCache:
+                    Logger.v("Event \(event) triggered")
+                    if isTriggered(internal: .splitsLoadedFromCache),
+                       isTriggered(internal: .mySegmentsLoadedFromCache),
+                       isTriggered(internal: .myLargeSegmentsLoadedFromCache),
+                       isTriggered(internal: .attributesLoadedFromCache) {
+                        trigger(event: .sdkReadyFromCache)
+                    }
+                case .splitKilledNotification:
+                    if isTriggered(external: .sdkReady) {
+                        trigger(event: .sdkUpdated, metadata: event.metadata)
+                        continue
+                    }
+                case .sdkReadyTimeoutReached:
+                    if !isTriggered(external: .sdkReady) {
+                        trigger(event: .sdkReadyTimedOut)
+                    }
             }
         }
     }

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -262,7 +262,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
     }
 
     private func isTriggered(internal event: SplitInternalEventWithMetadata) -> Bool {
-        return triggered.filter { $0 == event }.count > 0
+        return triggered.filter { event.isSameType($0) }.count > 0
     }
     
     private func isTriggered(internal event: SplitInternalEvent) -> Bool {

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -176,7 +176,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
                 }
             case .splitKilledNotification:
                 if isTriggered(external: .sdkReady) {
-                    trigger(event: .sdkUpdated)
+                    trigger(event: .sdkUpdated, metadata: event.metadata)
                     continue
                 }
             case .sdkReadyTimeoutReached:

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -25,7 +25,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
 
     private var subscriptions = [SplitEvent: [SplitEventTask]]()
     private var executionTimes: [String: Int]
-    private var triggered: [SplitInternalEventWithMetadata]
+    private var triggered: [SplitInternalEvent]
     private let processQueue: DispatchQueue
     private let dataAccessQueue: DispatchQueue
     private var isStarted: Bool
@@ -37,7 +37,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         self.isStarted = false
         self.sdkReadyTimeStart = Date().unixTimestampInMiliseconds()
         self.readingRefreshTime = 300
-        self.triggered = [SplitInternalEventWithMetadata]()
+        self.triggered = [SplitInternalEvent]()
         self.eventsQueue = DefaultInternalEventBlockingQueue()
         self.executionTimes = [String: Int]()
         registerMaxAllowedExecutionTimesPerEvent()
@@ -157,7 +157,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
             guard let event = takeEvent() else {
                 return
             }
-            self.triggered.append(event)
+            self.triggered.append(event.type)
             switch event.type {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
                 if isTriggered(external: .sdkReady) {
@@ -260,13 +260,9 @@ class DefaultSplitEventsManager: SplitEventsManager {
             task.run(event.metadata)
         }
     }
-
-    private func isTriggered(internal event: SplitInternalEventWithMetadata) -> Bool {
-        return triggered.filter { event.isSameType($0) }.count > 0
-    }
     
     private func isTriggered(internal event: SplitInternalEvent) -> Bool {
-        return isTriggered(internal: SplitInternalEventWithMetadata(event, metadata: nil))
+        return triggered.filter { $0 == event }.count > 0
     }
 
     // MARK: Safe Data Access

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -9,8 +9,10 @@
 import Foundation
 
 protocol SplitEventsManager: AnyObject {
-    func register(event: SplitEvent, task: SplitEventTask)
+    func register(event: SplitEvent, task: SplitEventActionTask)
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask)
     func notifyInternalEvent(_ event: SplitInternalEvent)
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata?)
     func start()
     func stop()
     func eventAlreadyTriggered(event: SplitEvent) -> Bool
@@ -23,7 +25,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
 
     private var subscriptions = [SplitEvent: [SplitEventTask]]()
     private var executionTimes: [String: Int]
-    private var triggered: [SplitInternalEvent]
+    private var triggered: [SplitInternalEventWithMetadata]
     private let processQueue: DispatchQueue
     private let dataAccessQueue: DispatchQueue
     private var isStarted: Bool
@@ -35,7 +37,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         self.isStarted = false
         self.sdkReadyTimeStart = Date().unixTimestampInMiliseconds()
         self.readingRefreshTime = 300
-        self.triggered = [SplitInternalEvent]()
+        self.triggered = [SplitInternalEventWithMetadata]()
         self.eventsQueue = DefaultInternalEventBlockingQueue()
         self.executionTimes = [String: Int]()
         registerMaxAllowedExecutionTimesPerEvent()
@@ -48,18 +50,24 @@ class DefaultSplitEventsManager: SplitEventsManager {
             }
         }
     }
+    
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata? = nil) {
+        let event = SplitInternalEventWithMetadata(event, metadata: metadata)
 
-    func notifyInternalEvent(_ event: SplitInternalEvent) {
         processQueue.async { [weak self] in
             if let self = self {
-                Logger.v("Event \(event) notified")
                 self.eventsQueue.add(event)
             }
         }
     }
 
-    func register(event: SplitEvent, task: SplitEventTask) {
-        let eventName = event.toString()
+    // Method kept for backwards compatibility. Allows notifying an event without metadata.
+    func notifyInternalEvent(_ event: SplitInternalEvent) {
+        notifyInternalEvent(event, metadata: nil)
+    }
+
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
+        let eventName = event.type.toString()
         processQueue.async { [weak self] in
             guard let self = self else { return }
             // If event is already triggered, execute the task
@@ -67,8 +75,13 @@ class DefaultSplitEventsManager: SplitEventsManager {
                 self.executeTask(event: event, task: task)
                 return
             }
-            self.subscribe(task: task, to: event)
+            self.subscribe(task: task, to: event.type)
         }
+    }
+    
+    // Method kept for backwards compatibility. Allows registering an event without metadata.
+    func register(event: SplitEvent, task: SplitEventActionTask) {
+        register(event: SplitEventWithMetadata(type: event, metadata: nil), task: task)
     }
 
     func start() {
@@ -128,7 +141,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         return isRunning
     }
 
-    private func takeEvent() -> SplitInternalEvent? {
+    private func takeEvent() -> SplitInternalEventWithMetadata? {
         do {
             return try eventsQueue.take()
         } catch BlockingQueueError.hasBeenStopped {
@@ -145,7 +158,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
                 return
             }
             self.triggered.append(event)
-            switch event {
+            switch event.type {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
                 if isTriggered(external: .sdkReady) {
                     trigger(event: .sdkUpdated)
@@ -201,7 +214,11 @@ class DefaultSplitEventsManager: SplitEventsManager {
     }
 
     private func trigger(event: SplitEvent) {
-        let eventName = event.toString()
+        trigger(event: SplitEventWithMetadata(type: event, metadata: nil))
+    }
+
+    private func trigger(event: SplitEventWithMetadata) {
+        let eventName = event.type.toString()
 
         // If executionTimes is zero, maximum executions has been reached
         if executionTimes(for: eventName) == 0 {
@@ -215,14 +232,14 @@ class DefaultSplitEventsManager: SplitEventsManager {
 
         Logger.d("Triggering SDK event \(eventName)")
         // If executionTimes is lower than zero, execute it without limitation
-        if let subscriptions = getSubscriptions(for: event) {
+        if let subscriptions = getSubscriptions(for: event.type) {
             for task in subscriptions {
                 executeTask(event: event, task: task)
             }
         }
     }
 
-    private func executeTask(event: SplitEvent, task: SplitEventTask) {
+    private func executeTask(event: SplitEventWithMetadata, task: SplitEventTask) {
 
         let eventName = task.event.toString()
 
@@ -232,7 +249,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
             let queue = task.takeQueue() ?? DispatchQueue.general
             queue.async {
                 TimeChecker.logInterval("Running \(eventName) in Background queue \(queue)")
-                task.run()
+                task.run(event.metadata)
             }
             return
         }
@@ -240,12 +257,16 @@ class DefaultSplitEventsManager: SplitEventsManager {
         DispatchQueue.main.async {
             TimeChecker.logInterval("Running event on main: \(eventName)")
             // UI Updates
-            task.run()
+            task.run(event.metadata)
         }
     }
 
-    private func isTriggered(internal event: SplitInternalEvent) -> Bool {
+    private func isTriggered(internal event: SplitInternalEventWithMetadata) -> Bool {
         return triggered.filter { $0 == event }.count > 0
+    }
+    
+    private func isTriggered(internal event: SplitInternalEvent) -> Bool {
+        return isTriggered(internal: SplitInternalEventWithMetadata(event, metadata: nil))
     }
 
     // MARK: Safe Data Access

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -61,7 +61,6 @@ class DefaultSplitEventsManager: SplitEventsManager {
         }
     }
 
-    // Method kept for backwards compatibility. Allows notifying an event without metadata.
     func notifyInternalEvent(_ event: SplitInternalEvent) {
         notifyInternalEvent(event, metadata: nil)
     }
@@ -161,7 +160,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
             switch event.type {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
                 if isTriggered(external: .sdkReady) {
-                    trigger(event: .sdkUpdated)
+                    trigger(event: .sdkUpdated, metadata: event.metadata)
                     continue
                 }
                 self.triggerSdkReadyIfNeeded()
@@ -213,8 +212,8 @@ class DefaultSplitEventsManager: SplitEventsManager {
         }
     }
 
-    private func trigger(event: SplitEvent) {
-        trigger(event: SplitEventWithMetadata(type: event, metadata: nil))
+    private func trigger(event: SplitEvent, metadata: EventMetadata? = nil) {
+        trigger(event: SplitEventWithMetadata(type: event, metadata: metadata))
     }
 
     private func trigger(event: SplitEventWithMetadata) {

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -155,13 +155,13 @@ class DefaultSplitEventsManager: SplitEventsManager {
     }
 
     private func processEvents() {
+        
         while isRunning() {
-            guard let event = takeEvent() else {
-                return
-            }
-            self.triggered.append(event.type)
+            guard let event = takeEvent() else { return }
+            triggered.append(event.type)
+            
             switch event.type {
-                case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
+                case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated, .ruleBasedSegmentsUpdated:
                     if isTriggered(external: .sdkReady) {
                         trigger(event: .sdkUpdated, metadata: event.metadata)
                         continue

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -173,7 +173,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
                    isTriggered(internal: .mySegmentsLoadedFromCache),
                    isTriggered(internal: .myLargeSegmentsLoadedFromCache),
                    isTriggered(internal: .attributesLoadedFromCache) {
-                    trigger(event: SplitEvent.sdkReadyFromCache)
+                    trigger(event: .sdkReadyFromCache)
                 }
             case .splitKilledNotification:
                 if isTriggered(external: .sdkReady) {
@@ -182,7 +182,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
                 }
             case .sdkReadyTimeoutReached:
                 if !isTriggered(external: .sdkReady) {
-                    trigger(event: SplitEvent.sdkReadyTimedOut)
+                    trigger(event: .sdkReadyTimedOut)
                 }
             }
         }

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -10,14 +10,6 @@ struct SplitInternalEventWithMetadata: Equatable {
         self.type = type
         self.metadata = metadata
     }
-    
-    public static func == (lhs: SplitInternalEventWithMetadata, rhs: SplitInternalEventWithMetadata) -> Bool {
-        return lhs.type == rhs.type && lhs.metadata == rhs.metadata
-    }
-    
-    func isSameType(_ other: SplitInternalEventWithMetadata) -> Bool {
-        return self.type == other.type
-    }
 }
 
 enum SplitInternalEvent {

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -1,11 +1,20 @@
-//
-//  SplitInternalEvent.swift
-//  Split
-//
 //  Created by Sebastian Arrubia on 4/16/18.
-//
 
 import Foundation
+
+struct SplitInternalEventWithMetadata {
+    let type: SplitInternalEvent
+    let metadata: EventMetadata?
+
+    init(_ type: SplitInternalEvent, metadata: EventMetadata? = nil) {
+        self.type = type
+        self.metadata = metadata
+    }
+
+    static func == (lhs: SplitInternalEventWithMetadata, rhs: SplitInternalEventWithMetadata) -> Bool {
+        return lhs.type == rhs.type
+    }
+}
 
 enum SplitInternalEvent {
     case mySegmentsUpdated

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -15,6 +15,7 @@ struct SplitInternalEventWithMetadata: Equatable {
 enum SplitInternalEvent {
     case mySegmentsUpdated
     case myLargeSegmentsUpdated
+    case ruleBasedSegmentsUpdated
     case splitsUpdated
     case mySegmentsLoadedFromCache
     case myLargeSegmentsLoadedFromCache

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -2,13 +2,21 @@
 
 import Foundation
 
-struct SplitInternalEventWithMetadata {
+struct SplitInternalEventWithMetadata: Equatable {
     let type: SplitInternalEvent
     let metadata: EventMetadata?
 
     init(_ type: SplitInternalEvent, metadata: EventMetadata? = nil) {
         self.type = type
         self.metadata = metadata
+    }
+    
+    public static func == (lhs: SplitInternalEventWithMetadata, rhs: SplitInternalEventWithMetadata) -> Bool {
+        return lhs.type == rhs.type && lhs.metadata == rhs.metadata
+    }
+    
+    func isSameType(_ other: SplitInternalEventWithMetadata) -> Bool {
+        return self.type == other.type
     }
 }
 

--- a/Split/Events/SplitInternalEvent.swift
+++ b/Split/Events/SplitInternalEvent.swift
@@ -10,10 +10,6 @@ struct SplitInternalEventWithMetadata {
         self.type = type
         self.metadata = metadata
     }
-
-    static func == (lhs: SplitInternalEventWithMetadata, rhs: SplitInternalEventWithMetadata) -> Bool {
-        return lhs.type == rhs.type
-    }
 }
 
 enum SplitInternalEvent {

--- a/Split/FetcherEngine/Refresh/ChangesChecker.swift
+++ b/Split/FetcherEngine/Refresh/ChangesChecker.swift
@@ -43,7 +43,7 @@ struct DefaultMySegmentsChangesChecker: MySegmentsChangesChecker {
         return !(oldSegments.count == newSegments.count &&
                  oldSegments.sorted() == newSegments.sorted())
     }
-    
+  
     func getSegmentsDiff(oldSegments: [Segment], newSegments: [Segment]) -> [String] {
         oldSegments.filter { !Set(newSegments.map { $0.name }).contains($0.name) }.map { $0.name }
     }

--- a/Split/FetcherEngine/Refresh/ChangesChecker.swift
+++ b/Split/FetcherEngine/Refresh/ChangesChecker.swift
@@ -22,6 +22,7 @@ protocol MySegmentsChangesChecker {
     func mySegmentsHaveChanged(old: SegmentChange, new: SegmentChange) -> Bool
     func mySegmentsHaveChanged(oldSegments: [Segment], newSegments: [Segment]) -> Bool
     func mySegmentsHaveChanged(oldSegments: [String], newSegments: [String]) -> Bool
+    func getSegmentsDiff(oldSegments: [Segment], newSegments: [Segment]) -> [String]
 }
 
 struct DefaultMySegmentsChangesChecker: MySegmentsChangesChecker {
@@ -42,5 +43,8 @@ struct DefaultMySegmentsChangesChecker: MySegmentsChangesChecker {
         return !(oldSegments.count == newSegments.count &&
                  oldSegments.sorted() == newSegments.sorted())
     }
-
+    
+    func getSegmentsDiff(oldSegments: [Segment], newSegments: [Segment]) -> [String] {
+        oldSegments.filter { !Set(newSegments.map { $0.name }).contains($0.name) }.map { $0.name }
+    }
 }

--- a/Split/FetcherEngine/Refresh/PeriodicSyncWorker.swift
+++ b/Split/FetcherEngine/Refresh/PeriodicSyncWorker.swift
@@ -130,10 +130,8 @@ class BasePeriodicSyncWorker: PeriodicSyncWorker {
         Logger.i("Fetch from remote not implemented")
     }
 
-    func notifyUpdate(_ events: [SplitInternalEvent]) {
-        events.forEach {
-            eventsManager.notifyInternalEvent($0)
-        }
+    func notifyUpdate(_ event: SplitInternalEvent, _ metadata: EventMetadata? = nil) {
+        eventsManager.notifyInternalEvent(event, metadata: metadata)
     }
 }
 
@@ -183,8 +181,10 @@ class PeriodicSplitsSyncWorker: BasePeriodicSyncWorker {
         guard let result = try? syncHelper.sync(since: changeNumber, rbSince: rbChangeNumber) else {
             return
         }
-        if result.success, result.featureFlagsUpdated || result.rbsUpdated {
-            notifyUpdate([.splitsUpdated])
+        
+        if result.success, result.featureFlagsUpdated.count > 0 {
+            let metadata = EventMetadata(type: .FLAGS_UPDATED, data: result.featureFlagsUpdated)
+            notifyUpdate(.splitsUpdated, metadata)
         }
     }
 }
@@ -225,7 +225,7 @@ class PeriodicMySegmentsSyncWorker: BasePeriodicSyncWorker {
             if result.success {
                 if  result.msUpdated || result.mlsUpdated {
                     // For now is not necessary specify which entity was updated
-                    notifyUpdate([.mySegmentsUpdated])
+                    notifyUpdate(.mySegmentsUpdated)
                 }
             }
         } catch {

--- a/Split/FetcherEngine/Refresh/PeriodicSyncWorker.swift
+++ b/Split/FetcherEngine/Refresh/PeriodicSyncWorker.swift
@@ -130,7 +130,7 @@ class BasePeriodicSyncWorker: PeriodicSyncWorker {
         Logger.i("Fetch from remote not implemented")
     }
 
-    func notifyUpdate(_ event: SplitInternalEvent, _ metadata: EventMetadata? = nil) {
+    func notifyUpdate(_ event: SplitInternalEvent, metadata: EventMetadata? = nil) {
         eventsManager.notifyInternalEvent(event, metadata: metadata)
     }
 }
@@ -184,7 +184,7 @@ class PeriodicSplitsSyncWorker: BasePeriodicSyncWorker {
         
         if result.success, result.featureFlagsUpdated.count > 0 {
             let metadata = EventMetadata(type: .FLAGS_UPDATED, data: result.featureFlagsUpdated)
-            notifyUpdate(.splitsUpdated, metadata)
+            notifyUpdate(.splitsUpdated, metadata: metadata)
         }
     }
 }
@@ -223,9 +223,14 @@ class PeriodicMySegmentsSyncWorker: BasePeriodicSyncWorker {
                                              mlsTill: myLargeSegmentsStorage.changeNumber,
                                              headers: nil)
             if result.success {
-                if  result.msUpdated || result.mlsUpdated {
+                if !result.msUpdated.isEmpty || !result.mlsUpdated.isEmpty {
                     // For now is not necessary specify which entity was updated
-                    notifyUpdate(.mySegmentsUpdated)
+                    if !result.msUpdated.isEmpty {
+                        notifyUpdate(.mySegmentsUpdated, metadata: EventMetadata(type: .SEGMENTS_UPDATED, data: result.msUpdated))
+                    }
+                    if !result.mlsUpdated.isEmpty {
+                        notifyUpdate(.myLargeSegmentsUpdated, metadata: EventMetadata(type: .LARGE_SEGMENTS_UPDATED, data: result.msUpdated))
+                    }
                 }
             }
         } catch {

--- a/Split/FetcherEngine/Refresh/RetryableSegmentsSyncWorker.swift
+++ b/Split/FetcherEngine/Refresh/RetryableSegmentsSyncWorker.swift
@@ -46,11 +46,11 @@ class RetryableMySegmentsSyncWorker: BaseRetryableSyncWorker {
             if result.success {
                 if !isSdkReadyTriggered() {
                     // Notifying both to trigger SDK Ready
-                    notifyUpdate([.mySegmentsUpdated])
-                    notifyUpdate([.myLargeSegmentsUpdated])
+                    notifyUpdate(.mySegmentsUpdated)
+                    notifyUpdate(.myLargeSegmentsUpdated)
                 } else if  result.msUpdated || result.mlsUpdated {
                     // For now is not necessary specify which entity was updated
-                    notifyUpdate([.mySegmentsUpdated])
+                    notifyUpdate(.mySegmentsUpdated)
                 }
                 return true
             }

--- a/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
+++ b/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
@@ -12,7 +12,7 @@ struct SyncResult {
     let success: Bool
     let changeNumber: Int64
     let rbChangeNumber: Int64?
-    let featureFlagsUpdated: Bool
+    let featureFlagsUpdated: [String]
     let rbsUpdated: Bool
 }
 
@@ -21,7 +21,7 @@ class SplitsSyncHelper {
     struct FetchResult {
         let till: Int64
         let rbTill: Int64?
-        let featureFlagsUpdated: Bool
+        let featureFlagsUpdated: [String]
         let rbsUpdated: Bool
     }
 
@@ -163,7 +163,7 @@ class SplitsSyncHelper {
         return SyncResult(success: false,
                           changeNumber: nextSince,
                           rbChangeNumber: nextRbSince,
-                          featureFlagsUpdated: false,
+                          featureFlagsUpdated: [],
                           rbsUpdated: false)
     }
 
@@ -177,7 +177,7 @@ class SplitsSyncHelper {
         var firstFetch = true
         var nextSince = since
         var nextRbSince = rbSince
-        var featureFlagsUpdated = false
+        var featureFlagsUpdated: [String] = []
         var rbsUpdated = false
         while true {
             clearCache = clearCache && firstFetch
@@ -202,8 +202,9 @@ class SplitsSyncHelper {
                 ruleBasedSegmentsStorage.clear()
             }
             firstFetch = false
-            if splitsStorage.update(splitChange: splitChangeProcessor.process(targetingRulesChange.featureFlags)) {
-                featureFlagsUpdated = true
+            let processedSplits = splitChangeProcessor.process(flagsChange)
+            if splitsStorage.update(splitChange: processedSplits) {
+                featureFlagsUpdated = (processedSplits.archivedSplits + processedSplits.activeSplits).compactMap(\.name)
             }
             
             let processedChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)

--- a/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
+++ b/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
@@ -13,7 +13,7 @@ struct SyncResult {
     let changeNumber: Int64
     let rbChangeNumber: Int64?
     let featureFlagsUpdated: [String]
-    let rbsUpdated: Bool
+    let rbsUpdated: [String]
 }
 
 class SplitsSyncHelper {
@@ -22,7 +22,7 @@ class SplitsSyncHelper {
         let till: Int64
         let rbTill: Int64?
         let featureFlagsUpdated: [String]
-        let rbsUpdated: Bool
+        let rbsUpdated: [String]
     }
 
     private let splitFetcher: HttpSplitFetcher
@@ -164,7 +164,7 @@ class SplitsSyncHelper {
                           changeNumber: nextSince,
                           rbChangeNumber: nextRbSince,
                           featureFlagsUpdated: [],
-                          rbsUpdated: false)
+                          rbsUpdated: [])
     }
 
     func fetchUntil(since: Int64,
@@ -178,7 +178,7 @@ class SplitsSyncHelper {
         var nextSince = since
         var nextRbSince = rbSince
         var featureFlagsUpdated: [String] = []
-        var rbsUpdated = false
+        var rbsUpdated: [String] = []
         while true {
             clearCache = clearCache && firstFetch
             // Determine which spec version to use and whether to include rbSince
@@ -202,14 +202,18 @@ class SplitsSyncHelper {
                 ruleBasedSegmentsStorage.clear()
             }
             firstFetch = false
+            
+            // FLAGS PROCESSING
             let processedSplits = splitChangeProcessor.process(flagsChange)
             if splitsStorage.update(splitChange: processedSplits) {
                 featureFlagsUpdated = (processedSplits.archivedSplits + processedSplits.activeSplits).compactMap(\.name)
             }
             
-            let processedChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)
-            if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd, toRemove: processedChange.toRemove, changeNumber: processedChange.changeNumber) {
-                rbsUpdated = true
+            // RULE BASED SEGMENTS PROCESSING
+            let processedRuleBasedSegmentChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)
+            if ruleBasedSegmentsStorage.update(toAdd: processedRuleBasedSegmentChange.toAdd, toRemove: processedRuleBasedSegmentChange.toRemove, changeNumber: processedRuleBasedSegmentChange.changeNumber) {
+                rbsUpdated += processedRuleBasedSegmentChange.archivedSegments.compactMap(\.name)
+                rbsUpdated += processedRuleBasedSegmentChange.activeSegments.compactMap(\.name)
             }
 
             Logger.i("Feature flag definitions have been updated")

--- a/Split/Localhost/LocalhostSynchronizer.swift
+++ b/Split/Localhost/LocalhostSynchronizer.swift
@@ -44,7 +44,10 @@ class LocalhostSynchronizer: FeatureFlagsSynchronizer {
     func notifyKilled(flag: String) {
     }
 
-    func notifyUpdated(flagsList: [String]) {
+    func notifyUpdated(flags: [String]) {
+    }
+    
+    @objc(notifyUpdatedWithRuleBasedSegments:) func notifyUpdated(ruleBasedSegments segments: [String]) {
     }
 
     func pause() {

--- a/Split/Localhost/LocalhostSynchronizer.swift
+++ b/Split/Localhost/LocalhostSynchronizer.swift
@@ -74,7 +74,9 @@ class LocalhostSynchronizer: FeatureFlagsSynchronizer {
             // Update will remove all records before insert new ones
             _ = self.featureFlagsStorage.update(splitChange: change)
 
-            self.eventsManager.notifyInternalEvent(.splitsUpdated, metadata: EventMetadata(type: .FLAGS_UPDATED, data: values.map { $0.name ?? "" } ))
+            // Notify event
+            let metadata = EventMetadata(type: .FLAGS_UPDATED, data: values.map { $0.name ?? "" } )
+            self.eventsManager.notifyInternalEvent(.splitsUpdated, metadata: metadata)
         }
     }
 }

--- a/Split/Localhost/LocalhostSynchronizer.swift
+++ b/Split/Localhost/LocalhostSynchronizer.swift
@@ -41,7 +41,7 @@ class LocalhostSynchronizer: FeatureFlagsSynchronizer {
     func stopPeriodicSync() {
     }
 
-    func notifyKilled() {
+    func notifyKilled(flag: String) {
     }
 
     func notifyUpdated(flagsList: [String]) {

--- a/Split/Localhost/LocalhostSynchronizer.swift
+++ b/Split/Localhost/LocalhostSynchronizer.swift
@@ -44,7 +44,7 @@ class LocalhostSynchronizer: FeatureFlagsSynchronizer {
     func notifyKilled() {
     }
 
-    func notifyUpdated() {
+    func notifyUpdated(flagsList: [String]) {
     }
 
     func pause() {
@@ -74,7 +74,7 @@ class LocalhostSynchronizer: FeatureFlagsSynchronizer {
             // Update will remove all records before insert new ones
             _ = self.featureFlagsStorage.update(splitChange: change)
 
-            self.eventsManager.notifyInternalEvent(.splitsUpdated)
+            self.eventsManager.notifyInternalEvent(.splitsUpdated, metadata: EventMetadata(type: .FLAGS_UPDATED, data: values.map { $0.name ?? "" } ))
         }
     }
 }

--- a/Split/Network/Streaming/PushNotificationManager.swift
+++ b/Split/Network/Streaming/PushNotificationManager.swift
@@ -134,14 +134,7 @@ class DefaultPushNotificationManager: PushNotificationManager {
         }
         Logger.d("Streaming authentication success")
 
-        var connectionDelay: Int64 = 0
-        
-        #if DEBUG
-            connectionDelay = 1
-        #else
-            connectionDelay = result.sseConnectionDelay
-        #endif
-        
+        let connectionDelay = result.sseConnectionDelay
         self.broadcasterChannel.push(event: .pushDelayReceived(delaySeconds: connectionDelay))
         let lastId = lastConnId.value
         if connectionDelay > 0 {

--- a/Split/Network/Streaming/PushNotificationManager.swift
+++ b/Split/Network/Streaming/PushNotificationManager.swift
@@ -134,7 +134,14 @@ class DefaultPushNotificationManager: PushNotificationManager {
         }
         Logger.d("Streaming authentication success")
 
-        let connectionDelay = result.sseConnectionDelay
+        var connectionDelay: Int64 = 0
+        
+        #if DEBUG
+            connectionDelay = 1
+        #else
+            connectionDelay = result.sseConnectionDelay
+        #endif
+        
         self.broadcasterChannel.push(event: .pushDelayReceived(delaySeconds: connectionDelay))
         let lastId = lastConnId.value
         if connectionDelay > 0 {

--- a/Split/Network/Streaming/SseNotificationProcessor.swift
+++ b/Split/Network/Streaming/SseNotificationProcessor.swift
@@ -36,18 +36,18 @@ class DefaultSseNotificationProcessor: SseNotificationProcessor {
     func process(_ notification: IncomingNotification) {
         Logger.d("Received notification \(notification.type)")
         switch notification.type {
-        case .splitUpdate:
-            processTargetingRuleUpdate(notification)
-        case .ruleBasedSegmentUpdate:
-            processTargetingRuleUpdate(notification)
-        case .mySegmentsUpdate:
-            processSegmentsUpdate(notification, updateWorker: mySegmentsUpdateWorker)
-        case .myLargeSegmentsUpdate:
-            processSegmentsUpdate(notification, updateWorker: myLargeSegmentsUpdateWorker)
-        case .splitKill:
-            processSplitKill(notification)
-        default:
-            Logger.e("Unknown notification arrived: \(notification.jsonData ?? "null" )")
+            case .splitUpdate:
+                processTargetingRuleUpdate(notification)
+            case .ruleBasedSegmentUpdate:
+                processTargetingRuleUpdate(notification)
+            case .mySegmentsUpdate:
+                processSegmentsUpdate(notification, updateWorker: mySegmentsUpdateWorker)
+            case .myLargeSegmentsUpdate:
+                processSegmentsUpdate(notification, updateWorker: myLargeSegmentsUpdateWorker)
+            case .splitKill:
+                processSplitKill(notification)
+            default:
+                Logger.e("Unknown notification arrived: \(notification.jsonData ?? "null" )")
         }
     }
 

--- a/Split/Network/Streaming/SyncSegmentsUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncSegmentsUpdateWorker.swift
@@ -110,7 +110,7 @@ class SegmentsUpdateWorker: UpdateWorker<MembershipsUpdateNotification> {
         if segments.count > newSegments.count {
             mySegmentsStorage.set(SegmentChange(segments: newSegments.asArray()),
                                   forKey: key)
-            synchronizer.notifyUpdate(forKey: key)
+            synchronizer.notifyUpdate(forKey: key, EventMetadata(type: .SEGMENTS_UPDATED, data: newSegments.asArray() ))
             telemetryProducer?.recordUpdatesFromSse(type: resource)
         }
     }
@@ -128,7 +128,7 @@ class SegmentsUpdateWorker: UpdateWorker<MembershipsUpdateNotification> {
                 if oldSegments.count < newSegments.count {
                     mySegmentsStorage.set(SegmentChange(segments: newSegments.asArray()),
                                           forKey: userKey)
-                    synchronizer.notifyUpdate(forKey: userKey)
+                    synchronizer.notifyUpdate(forKey: userKey, EventMetadata(type: .SEGMENTS_UPDATED, data: newSegments.asArray() ))
                     telemetryProducer?.recordUpdatesFromSse(type: .mySegments)
                 }
                 return
@@ -171,7 +171,7 @@ class SegmentsUpdateWorker: UpdateWorker<MembershipsUpdateNotification> {
 
 protocol SegmentsSynchronizerWrapper {
     func fetch(byKey: String, changeNumbers: SegmentsChangeNumber, delay: Int64)
-    func notifyUpdate(forKey: String)
+    func notifyUpdate(forKey: String, _ metadata: EventMetadata?)
 }
 
 class MySegmentsSynchronizerWrapper: SegmentsSynchronizerWrapper {
@@ -185,12 +185,13 @@ class MySegmentsSynchronizerWrapper: SegmentsSynchronizerWrapper {
         synchronizer.forceMySegmentsSync(forKey: key, changeNumbers: changeNumbers, delay: delay)
     }
 
-    func notifyUpdate(forKey key: String) {
-        synchronizer.notifySegmentsUpdated(forKey: key)
+    func notifyUpdate(forKey key: String, _ metadata: EventMetadata? = nil) {
+        synchronizer.notifySegmentsUpdated(forKey: key, metadata: metadata)
     }
 }
 
 class MyLargeSegmentsSynchronizerWrapper: SegmentsSynchronizerWrapper {
+    
     private let synchronizer: Synchronizer
 
     init(synchronizer: Synchronizer) {
@@ -201,8 +202,8 @@ class MyLargeSegmentsSynchronizerWrapper: SegmentsSynchronizerWrapper {
         synchronizer.forceMySegmentsSync(forKey: key, changeNumbers: changeNumbers, delay: delay)
     }
 
-    func notifyUpdate(forKey key: String) {
-        synchronizer.notifyLargeSegmentsUpdated(forKey: key)
+    func notifyUpdate(forKey key: String, _ metadata: EventMetadata? = nil) {
+        synchronizer.notifyLargeSegmentsUpdated(forKey: key, metadata: metadata)
     }
 }
 

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -227,7 +227,7 @@ class SplitKillWorker: UpdateWorker<SplitKillNotification> {
                 splitToKill.changeNumber = notification.changeNumber
                 splitToKill.killed = true
                 splitsStorage.updateWithoutChecks(split: splitToKill)
-                synchronizer.notifySplitKilled()
+                synchronizer.notifySplitKilled(flag: splitToKill.name ?? "")
             }
         }
         synchronizer.synchronizeSplits(changeNumber: notification.changeNumber)

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -174,8 +174,9 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
             if ruleBasedSegmentsStorage.update(toAdd: processedSegments.toAdd,
                                                   toRemove: processedSegments.toRemove,
                                                   changeNumber: processedSegments.changeNumber) {
-                var updatedSegments = (processedSegments.activeSegments + processedSegments.archivedSegments).compactMap(\.name)
-                synchronizer.notifyFeatureFlagsUpdated(flags: []) //TODO: Make new notify segments updated (new notification method?)
+                
+                let updatedSegments = processedSegments.activeSegments.compactMap(\.name) + processedSegments.archivedSegments.compactMap(\.name)
+                synchronizer.notifyRuleBasedSegmentsUpdated(segments: updatedSegments)
             }
             
             telemetryProducer?.recordUpdatesFromSse(type: .splits)

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -169,14 +169,15 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
             Logger.v("RBS update received: \(change)")
 
-            let processedChange = ruleBasedSegmentsChangeProcessor.process(change)
+            let processedSegments = ruleBasedSegmentsChangeProcessor.process(change)
 
-            if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
-                                               toRemove: processedChange.toRemove,
-                                               changeNumber: processedChange.changeNumber) {
-                synchronizer.notifyFeatureFlagsUpdated(flags: []) //TODO: RBS Update
+            if ruleBasedSegmentsStorage.update(toAdd: processedSegments.toAdd,
+                                                  toRemove: processedSegments.toRemove,
+                                                  changeNumber: processedSegments.changeNumber) {
+                var updatedSegments = (processedSegments.activeSegments + processedSegments.archivedSegments).compactMap(\.name)
+                synchronizer.notifyFeatureFlagsUpdated(flags: []) //TODO: Make new notify segments updated (new notification method?)
             }
-
+            
             telemetryProducer?.recordUpdatesFromSse(type: .splits)
             return true
         } catch {

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -124,14 +124,11 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
     }
 
     /// Process a split update notification
-    private func processSplitUpdate(payload: String,
-                                   compressionType: CompressionType,
-                                   previousChangeNumber: Int64,
-                                   changeNumber: Int64) -> Bool {
+    private func processSplitUpdate(payload: String,compressionType: CompressionType,
+                                    previousChangeNumber: Int64,
+                                    changeNumber: Int64) -> Bool {
         do {
-            let split = try self.payloadDecoder.decode(
-                payload: payload,
-                compressionUtil: self.decomProvider.decompressor(for: compressionType))
+            let split = try payloadDecoder.decode(payload: payload, compressionUtil: decomProvider.decompressor(for: compressionType))
 
             if !allRuleBasedSegmentsExist(in: split) {
                 return false
@@ -143,11 +140,14 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
             Logger.v("Split update received: \(change)")
 
-            if self.splitsStorage.update(splitChange: self.splitChangeProcessor.process(change)) {
-                self.synchronizer.notifyFeatureFlagsUpdated()
+            let processedFlags = splitChangeProcessor.process(change)
+            
+            if splitsStorage.update(splitChange: processedFlags) {
+                let updatedFlags = (processedFlags.activeSplits + processedFlags.archivedSplits).compactMap(\.name)
+                synchronizer.notifyFeatureFlagsUpdated(flags: updatedFlags)
             }
 
-            self.telemetryProducer?.recordUpdatesFromSse(type: .splits)
+            telemetryProducer?.recordUpdatesFromSse(type: .splits)
             return true
         } catch {
             Logger.e("Error decoding feature flags payload from notification: \(error)")
@@ -157,29 +157,27 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a rule-based segment update notification
     private func processRuleBasedSegmentUpdate(payload: String,
-                                             compressionType: CompressionType,
-                                             previousChangeNumber: Int64,
-                                             changeNumber: Int64) -> Bool {
+                                               compressionType: CompressionType,
+                                               previousChangeNumber: Int64,
+                                               changeNumber: Int64) -> Bool {
         do {
-            let rbs = try self.ruleBasedSegmentsPayloadDecoder.decode(
-                payload: payload,
-                compressionUtil: self.decomProvider.decompressor(for: compressionType))
+            let rbs = try ruleBasedSegmentsPayloadDecoder.decode(payload: payload, compressionUtil: decomProvider.decompressor(for: compressionType))
 
             let change = RuleBasedSegmentChange(segments: [rbs],
-                                             since: previousChangeNumber,
-                                             till: changeNumber)
+                                                since: previousChangeNumber,
+                                                till: changeNumber)
 
             Logger.v("RBS update received: \(change)")
 
             let processedChange = ruleBasedSegmentsChangeProcessor.process(change)
 
-            if self.ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
-                                                  toRemove: processedChange.toRemove,
-                                                  changeNumber: processedChange.changeNumber) {
-                self.synchronizer.notifyFeatureFlagsUpdated()
+            if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
+                                               toRemove: processedChange.toRemove,
+                                               changeNumber: processedChange.changeNumber) {
+                synchronizer.notifyFeatureFlagsUpdated(flags: []) //TODO: RBS Update
             }
 
-            self.telemetryProducer?.recordUpdatesFromSse(type: .splits)
+            telemetryProducer?.recordUpdatesFromSse(type: .splits)
             return true
         } catch {
             Logger.e("Error decoding rule based segments payload from notification: \(error)")

--- a/Split/Network/Sync/ByKeyFacade.swift
+++ b/Split/Network/Sync/ByKeyFacade.swift
@@ -19,8 +19,8 @@ protocol ByKeyRegistry {
 protocol ByKeySynchronizer {
     func loadMySegmentsFromCache(forKey: String)
     func loadAttributesFromCache(forKey: String)
-    func notifyMySegmentsUpdated(forKey: String)
-    func notifyMyLargeSegmentsUpdated(forKey: String)
+    func notifyMySegmentsUpdated(forKey: String, metadata: EventMetadata?)
+    func notifyMyLargeSegmentsUpdated(forKey: String, metadata: EventMetadata?)
     func startSync(forKey key: Key)
     func startPeriodicSync()
     func stopPeriodicSync()
@@ -120,15 +120,15 @@ class DefaultByKeyFacade: ByKeyFacade {
         byKeyComponents.value(forKey: key)?.mySegmentsSynchronizer.synchronizeMySegments()
     }
 
-    func notifyMySegmentsUpdated(forKey key: String) {
+    func notifyMySegmentsUpdated(forKey key: String, metadata: EventMetadata?) {
         doInAll(forMatchingKey: key) { group in
-            group.eventsManager.notifyInternalEvent(.mySegmentsUpdated)
+            group.eventsManager.notifyInternalEvent(.mySegmentsUpdated, metadata: metadata)
         }
     }
 
-    func notifyMyLargeSegmentsUpdated(forKey key: String) {
+    func notifyMyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
         doInAll(forMatchingKey: key) { group in
-            group.eventsManager.notifyInternalEvent(.myLargeSegmentsUpdated)
+            group.eventsManager.notifyInternalEvent(.myLargeSegmentsUpdated, metadata: metadata)
         }
     }
 

--- a/Split/Network/Sync/ByKeyFacade.swift
+++ b/Split/Network/Sync/ByKeyFacade.swift
@@ -178,9 +178,7 @@ class DefaultByKeyFacade: ByKeyFacade {
         }
     }
 
-    private func doInAll(forMatchingKey key: String,
-                         action: (ByKeyComponentGroup) -> Void) {
-
+    private func doInAll(forMatchingKey key: String, action: (ByKeyComponentGroup) -> Void) {
         byKeyComponents.values(forMatchingKey: key).forEach {  group in
             action(group)
         }

--- a/Split/Network/Sync/ByKeyFacade.swift
+++ b/Split/Network/Sync/ByKeyFacade.swift
@@ -132,6 +132,7 @@ class DefaultByKeyFacade: ByKeyFacade {
         }
     }
 
+    // MARK: Cycle
     func pause() {
         doInAll { group in
             group.mySegmentsSynchronizer.pause()
@@ -171,6 +172,7 @@ class DefaultByKeyFacade: ByKeyFacade {
         return byKeyComponents.count == 0
     }
 
+    // MARK: Helpers
     private func doInAll(_ action: (ByKeyComponentGroup) -> Void) {
         let all = byKeyComponents.all
         for (_, sync) in all {

--- a/Split/Network/Sync/ByKeyFacade.swift
+++ b/Split/Network/Sync/ByKeyFacade.swift
@@ -77,7 +77,7 @@ class DefaultByKeyFacade: ByKeyFacade {
     func loadAttributesFromCache(forKey key: String) {
         doInAll(forMatchingKey: key) { group in
             group.attributesStorage.loadLocal()
-            group.eventsManager.notifyInternalEvent(.attributesLoadedFromCache)
+            group.eventsManager.notifyInternalEvent(.attributesLoadedFromCache, metadata: nil)
         }
         TimeChecker.logInterval("Time until attributes loaded from cache")
     }

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -15,7 +15,7 @@ protocol FeatureFlagsSynchronizer {
     func startPeriodicSync()
     func stopPeriodicSync()
     func notifyKilled()
-    func notifyUpdated()
+    func notifyUpdated(flagsList: [String])
     func pause()
     func resume()
     func destroy()
@@ -148,8 +148,8 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
         splitEventsManager.notifyInternalEvent(.splitKilledNotification)
     }
 
-    func notifyUpdated() {
-        splitEventsManager.notifyInternalEvent(.splitsUpdated)
+    func notifyUpdated(flagsList: [String]) {
+        splitEventsManager.notifyInternalEvent(.splitsUpdated, metadata: EventMetadata(type: .FLAGS_UPDATED, data: flagsList))
     }
 
     func pause() {

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -14,7 +14,7 @@ protocol FeatureFlagsSynchronizer {
     func synchronize(changeNumber: Int64?, rbsChangeNumber: Int64?)
     func startPeriodicSync()
     func stopPeriodicSync()
-    func notifyKilled()
+    func notifyKilled(flag: String)
     func notifyUpdated(flagsList: [String])
     func pause()
     func resume()
@@ -144,8 +144,8 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
         periodicSplitsSyncWorker?.stop()
     }
 
-    func notifyKilled() {
-        splitEventsManager.notifyInternalEvent(.splitKilledNotification)
+    func notifyKilled(flag: String) {
+        splitEventsManager.notifyInternalEvent(.splitKilledNotification, metadata: EventMetadata(type: .FLAGS_KILLED, data: [flag]))
     }
 
     func notifyUpdated(flagsList: [String]) {

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -78,7 +78,7 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
             return
         }
 
-        let splitsStorage = self.storageContainer.splitsStorage
+        let splitsStorage = storageContainer.splitsStorage
         DispatchQueue.general.async {
             let start = Date.nowMillis()
             self.filterSplitsInCache()

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -15,7 +15,8 @@ protocol FeatureFlagsSynchronizer {
     func startPeriodicSync()
     func stopPeriodicSync()
     func notifyKilled(flag: String)
-    func notifyUpdated(flagsList: [String])
+    func notifyUpdated(flags: [String])
+    func notifyUpdated(ruleBasedSegments: [String])
     func pause()
     func resume()
     func destroy()
@@ -148,8 +149,12 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
         splitEventsManager.notifyInternalEvent(.splitKilledNotification, metadata: EventMetadata(type: .FLAGS_KILLED, data: [flag]))
     }
 
-    func notifyUpdated(flagsList: [String]) {
-        splitEventsManager.notifyInternalEvent(.splitsUpdated, metadata: EventMetadata(type: .FLAGS_UPDATED, data: flagsList))
+    func notifyUpdated(flags: [String]) {
+        splitEventsManager.notifyInternalEvent(.splitsUpdated, metadata: EventMetadata(type: .FLAGS_UPDATED, data: flags))
+    }
+    
+    func notifyUpdated(ruleBasedSegments segments: [String]) {
+        splitEventsManager.notifyInternalEvent(.ruleBasedSegmentsUpdated, metadata: EventMetadata(type: .RULE_BASED_SEGMENTS_UPDATED, data: segments))
     }
 
     func pause() {

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -31,8 +31,8 @@ protocol Synchronizer: ImpressionLogger {
     func stopRecordingTelemetry()
     func pushEvent(event: EventDTO)
     func notifyFeatureFlagsUpdated(flags: [String])
-    func notifySegmentsUpdated(forKey key: String)
-    func notifyLargeSegmentsUpdated(forKey key: String)
+    func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata?)
+    func notifyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata?)
     func notifySplitKilled(flag: String)
     func pause()
     func resume()
@@ -211,12 +211,12 @@ class DefaultSynchronizer: Synchronizer {
         featureFlagsSynchronizer.notifyUpdated(flagsList: flags)
     }
 
-    func notifySegmentsUpdated(forKey key: String) {
-        byKeySynchronizer.notifyMySegmentsUpdated(forKey: key)
+    func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
+        byKeySynchronizer.notifyMySegmentsUpdated(forKey: key, metadata: metadata)
     }
 
-    func notifyLargeSegmentsUpdated(forKey key: String) {
-        byKeySynchronizer.notifyMyLargeSegmentsUpdated(forKey: key)
+    func notifyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
+        byKeySynchronizer.notifyMyLargeSegmentsUpdated(forKey: key, metadata: metadata)
     }
 
     func notifySplitKilled(flag: String) {

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -30,7 +30,7 @@ protocol Synchronizer: ImpressionLogger {
     func startRecordingTelemetry()
     func stopRecordingTelemetry()
     func pushEvent(event: EventDTO)
-    func notifyFeatureFlagsUpdated()
+    func notifyFeatureFlagsUpdated(flags: [String])
     func notifySegmentsUpdated(forKey key: String)
     func notifyLargeSegmentsUpdated(forKey key: String)
     func notifySplitKilled()
@@ -207,8 +207,8 @@ class DefaultSynchronizer: Synchronizer {
         }
     }
 
-    func notifyFeatureFlagsUpdated() {
-        featureFlagsSynchronizer.notifyUpdated()
+    func notifyFeatureFlagsUpdated(flags: [String]) {
+        featureFlagsSynchronizer.notifyUpdated(flagsList: flags)
     }
 
     func notifySegmentsUpdated(forKey key: String) {

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -23,6 +23,7 @@ protocol Synchronizer: ImpressionLogger {
     func synchronizeMySegments(forKey key: String)
     func synchronizeTelemetryConfig()
     func forceMySegmentsSync(forKey key: String, changeNumbers: SegmentsChangeNumber, delay: Int64)
+    
     func startPeriodicFetching()
     func stopPeriodicFetching()
     func startRecordingUserData()
@@ -30,10 +31,13 @@ protocol Synchronizer: ImpressionLogger {
     func startRecordingTelemetry()
     func stopRecordingTelemetry()
     func pushEvent(event: EventDTO)
+    
     func notifyFeatureFlagsUpdated(flags: [String])
+    func notifySplitKilled(flag: String)
+    func notifyRuleBasedSegmentsUpdated(segments: [String])
     func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata?)
     func notifyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata?)
-    func notifySplitKilled(flag: String)
+    
     func pause()
     func resume()
     func flush()
@@ -208,7 +212,11 @@ class DefaultSynchronizer: Synchronizer {
     }
 
     func notifyFeatureFlagsUpdated(flags: [String]) {
-        featureFlagsSynchronizer.notifyUpdated(flagsList: flags)
+        featureFlagsSynchronizer.notifyUpdated(flags: flags)
+    }
+    
+    func notifyRuleBasedSegmentsUpdated(segments: [String]) {
+        featureFlagsSynchronizer.notifyUpdated(ruleBasedSegments: segments)
     }
 
     func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {

--- a/Split/Network/Sync/Synchronizer.swift
+++ b/Split/Network/Sync/Synchronizer.swift
@@ -33,7 +33,7 @@ protocol Synchronizer: ImpressionLogger {
     func notifyFeatureFlagsUpdated(flags: [String])
     func notifySegmentsUpdated(forKey key: String)
     func notifyLargeSegmentsUpdated(forKey key: String)
-    func notifySplitKilled()
+    func notifySplitKilled(flag: String)
     func pause()
     func resume()
     func flush()
@@ -219,8 +219,8 @@ class DefaultSynchronizer: Synchronizer {
         byKeySynchronizer.notifyMyLargeSegmentsUpdated(forKey: key)
     }
 
-    func notifySplitKilled() {
-        featureFlagsSynchronizer.notifyKilled()
+    func notifySplitKilled(flag: String) {
+        featureFlagsSynchronizer.notifyKilled(flag: flag)
     }
 
     func pause() {

--- a/SplitTests/Collections/BlockingQueueTest.swift
+++ b/SplitTests/Collections/BlockingQueueTest.swift
@@ -25,7 +25,7 @@ class BlockingQueueTest: XCTestCase {
             while true {
                 do {
                     let event = try queue.take()
-                    local.append(event)
+                    local.append(event.type)
                     if local.count == 4 {
                         endExp.fulfill()
                     }
@@ -60,7 +60,7 @@ class BlockingQueueTest: XCTestCase {
             while true {
                 do {
                     let event = try queue.take()
-                    local.append(event)
+                    local.append(event.type)
                 } catch {
                     endExp.fulfill()
                     interrupted = true
@@ -105,8 +105,8 @@ class BlockingQueueTest: XCTestCase {
             for _ in 0..<50000 {
                 do {
                     let event = try queue.take()
-                    local.append(event)
-                    print("Took: \(event)")
+                    local.append(event.type)
+                    print("Took: \(event.type)")
                 } catch {
                 }
             }
@@ -117,8 +117,8 @@ class BlockingQueueTest: XCTestCase {
             for _ in 0..<50000 {
                 do {
                     let event = try queue.take()
-                    local.append(event)
-                    print("Took QA1: \(event)")
+                    local.append(event.type)
+                    print("Took QA1: \(event.type)")
                 } catch {
                     print("\n\n\nERROR!!!!: \(error) \n\n\n")
                 }
@@ -129,9 +129,9 @@ class BlockingQueueTest: XCTestCase {
             for _ in 0..<50000 {
                 do {
                     let event = try queue.take()
-                    local.append(event)
+                    local.append(event.type)
                     Thread.sleep(forTimeInterval: 0.3)
-                    print("Took QA2: \(event)")
+                    print("Took QA2: \(event.type)")
                 } catch {
                 }
             }
@@ -142,8 +142,8 @@ class BlockingQueueTest: XCTestCase {
                 do {
                     Thread.sleep(forTimeInterval: 0.5)
                     let event = try queue.take()
-                    local.append(event)
-                    print("Took QA3: \(event)")
+                    local.append(event.type)
+                    print("Took QA3: \(event.type)")
                 } catch {
                 }
             }

--- a/SplitTests/Fake/InternalSplitClientStub.swift
+++ b/SplitTests/Fake/InternalSplitClientStub.swift
@@ -103,6 +103,9 @@ class InternalSplitClientStub: InternalSplitClient {
 
     func on(event: SplitEvent, execute action: @escaping SplitAction) {
     }
+    
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {
+    }
 
     func track(trafficType: String, eventType: String) -> Bool {
         return true

--- a/SplitTests/Fake/InternalSplitClientStub.swift
+++ b/SplitTests/Fake/InternalSplitClientStub.swift
@@ -95,86 +95,77 @@ class InternalSplitClientStub: InternalSplitClient {
         return ["": SplitResult(treatment: SplitConstants.control)]
     }
 
-    func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, execute action: @escaping SplitAction) {}
     
-    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {
-    }
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {}
 
     func track(trafficType: String, eventType: String) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, value: Double, properties: [String: Any]?) -> Bool {
-        return true
+        true
     }
 
     func setAttribute(name: String, value: Any) -> Bool {
-        return true
+        true
     }
 
     func getAttribute(name: String) -> Any? {
-        return nil
+        nil
     }
 
     func setAttributes(_ values: [String: Any]) -> Bool {
-        return true
+        true
     }
 
     func getAttributes() -> [String: Any]? {
-        return nil
+        nil
     }
 
     func removeAttribute(name: String) -> Bool {
-        return true
+        true
     }
 
     func clearAttributes() -> Bool {
-        return true
+        true
     }
     
-    func flush() {
-    }
+    func flush() {}
 
-    func destroy() {
-    }
+    func destroy() {}
 
-    func destroy(completion: (() -> Void)?) {
-    }
+    func destroy(completion: (() -> Void)?) {}
 
-    func on(event: SplitEvent, executeTask: SplitEventTask) {
-
-    }
+    func on(event: SplitEvent, executeTask: SplitEventTask) {}
 
     private func createControlTreatmentsDictionary<T>(splits: [String]) -> [String: T] where T: Any {
         var result = [String: T]()

--- a/SplitTests/Fake/Service/ByKeyFacadeMock.swift
+++ b/SplitTests/Fake/Service/ByKeyFacadeMock.swift
@@ -123,12 +123,16 @@ class ByKeyFacadeMock: ByKeyFacade {
     }
 
     var notifyMySegmentsUpdatedCalled = false
-    func notifyMySegmentsUpdated(forKey key: String) {
+    var updatedSegmentsMetadataForKey = [String : EventMetadata?]()
+    func notifyMySegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
+        updatedSegmentsMetadataForKey[key] = metadata
         notifyMySegmentsUpdatedCalled = true
     }
 
     var notifyMyLargeSegmentsUpdatedCalled = false
-    func notifyMyLargeSegmentsUpdated(forKey key: String) {
+    var updatedLargeSegmentsMetadataForKey = [String : EventMetadata?]()
+    func notifyMyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
+        updatedLargeSegmentsMetadataForKey[key] = metadata
         notifyMyLargeSegmentsUpdatedCalled = true
     }
    

--- a/SplitTests/Fake/Service/ChangesCheckerMock.swift
+++ b/SplitTests/Fake/Service/ChangesCheckerMock.swift
@@ -11,23 +11,29 @@ import Foundation
 @testable import Split
 
 class MySegmentsChangesCheckerMock: MySegmentsChangesChecker {
+
     var haveChanged = false
+    var diffSegments: [String] = []
     func mySegmentsHaveChanged(old: SegmentChange, new: SegmentChange) -> Bool {
-        return haveChanged
+        haveChanged
     }
 
     func mySegmentsHaveChanged(oldSegments old: [Segment], newSegments new: [Segment]) -> Bool {
-        return haveChanged
+        haveChanged
     }
 
     func mySegmentsHaveChanged(oldSegments old: [String], newSegments new: [String]) -> Bool {
-        return haveChanged
+        haveChanged
+    }
+    
+    func getSegmentsDiff(oldSegments: [Segment], newSegments: [Segment]) -> [String] {
+        diffSegments
     }
 }
 
 struct SplitsChangesCheckerMock: SplitsChangesChecker {
     var haveChanged = false
     func splitsHaveChanged(oldChangeNumber: Int64, newChangeNumber: Int64) -> Bool {
-        return haveChanged
+        haveChanged
     }
 }

--- a/SplitTests/Fake/Service/ChangesCheckerMock.swift
+++ b/SplitTests/Fake/Service/ChangesCheckerMock.swift
@@ -14,6 +14,7 @@ class MySegmentsChangesCheckerMock: MySegmentsChangesChecker {
 
     var haveChanged = false
     var diffSegments: [String] = []
+
     func mySegmentsHaveChanged(old: SegmentChange, new: SegmentChange) -> Bool {
         haveChanged
     }

--- a/SplitTests/Fake/Service/SplitEventsManagerCoordinatorStub.swift
+++ b/SplitTests/Fake/Service/SplitEventsManagerCoordinatorStub.swift
@@ -22,9 +22,13 @@ class SplitEventsManagerCoordinatorStub: SplitEventsManagerCoordinator {
         managers[key] = nil
     }
 
-    func register(event: SplitEvent, task: SplitEventTask) {
+    func register(event: SplitEvent, task: SplitEventActionTask) {
 
     }
+    
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {}
+
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata?) {}
 
     var notifiedEvents = Set<String>()
     func notifyInternalEvent(_ event: SplitInternalEvent) {

--- a/SplitTests/Fake/SplitClientStub.swift
+++ b/SplitTests/Fake/SplitClientStub.swift
@@ -95,6 +95,9 @@ class SplitClientStub: SplitClient {
     func on(event: SplitEvent, runInBackground: Bool, queue: DispatchQueue?, execute action: @escaping SplitAction) {
     }
 
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {
+    }
+    
     func track(trafficType: String, eventType: String) -> Bool {
         return true
     }

--- a/SplitTests/Fake/SplitClientStub.swift
+++ b/SplitTests/Fake/SplitClientStub.swift
@@ -83,83 +83,75 @@ class SplitClientStub: SplitClient {
         return ["feature": SplitResult(treatment: SplitConstants.control)]
     }
 
-    func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, queue: DispatchQueue, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, runInBackground: Bool, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, runInBackground: Bool, queue: DispatchQueue?, execute action: @escaping SplitAction) {
-    }
+    func on(event: SplitEvent, runInBackground: Bool, queue: DispatchQueue?, execute action: @escaping SplitAction) {}
 
-    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {
-    }
+    func on(event: SplitEvent, executeWithMetadata: @escaping SplitActionWithMetadata) {}
     
     func track(trafficType: String, eventType: String) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, value: Double) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, properties: [String:Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(trafficType: String, eventType: String, value: Double, properties: [String:Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, properties: [String:Any]?) -> Bool {
-        return true
+        true
     }
 
     func track(eventType: String, value: Double, properties: [String:Any]?) -> Bool {
-        return true
+        true
     }
 
     func setAttribute(name: String, value: Any) -> Bool {
-        return true
+        true
     }
 
     func getAttribute(name: String) -> Any? {
-        return nil
+        nil
     }
 
     func setAttributes(_ values: [String: Any]) -> Bool {
-        return true
+        true
     }
 
     func getAttributes() -> [String: Any]? {
-        return nil
+        nil
     }
 
     func removeAttribute(name: String) -> Bool {
-        return true
+        true
     }
 
     func clearAttributes() -> Bool {
-        return true
+        true
     }
 
-    func flush() {
-    }
+    func flush() {}
 
-    func destroy() {
-    }
+    func destroy() {}
 
-    func destroy(completion: (() -> Void)?) {
-    }
+    func destroy(completion: (() -> Void)?) {}
 }

--- a/SplitTests/Fake/SplitEventsManagerMock.swift
+++ b/SplitTests/Fake/SplitEventsManagerMock.swift
@@ -31,6 +31,8 @@ class SplitEventsManagerMock: SplitEventsManager {
     var isSdkUpdatedFired = false
 
     var isSdkReadyChecked = false
+    
+    var metadata: EventMetadata?
 
     func notifyInternalEvent(_ event:SplitInternalEvent) {
         switch event {
@@ -52,9 +54,13 @@ class SplitEventsManagerMock: SplitEventsManager {
         }
     }
 
-    var registeredEvents = [SplitEvent: SplitEventTask]()
-    func register(event: SplitEvent, task: SplitEventTask) {
-        registeredEvents[event] = task
+    var registeredEvents = [SplitEvent: SplitEventActionTask]()
+    func register(event: SplitEvent, task: SplitEventActionTask) {
+        register(event: SplitEventWithMetadata(type: event), task: task)
+    }
+    
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
+        registeredEvents[event.type] = task
     }
     
     func start() {
@@ -78,5 +84,10 @@ class SplitEventsManagerMock: SplitEventsManager {
         default:
             return true
         }
+    }
+    
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata?) {
+        self.metadata = metadata
+        notifyInternalEvent(event)
     }
 }

--- a/SplitTests/Fake/SplitEventsManagerStub.swift
+++ b/SplitTests/Fake/SplitEventsManagerStub.swift
@@ -15,11 +15,19 @@ class SplitEventsManagerStub: SplitEventsManager {
     var splitsKilledEventFiredCount = 0
     var splitsUpdatedEventFiredCount = 0
     var mySegmentsLoadedEventFiredCount = 0
+    var metadata: EventMetadata?
     var mySegmentsLoadedEventExp: XCTestExpectation?
     var startCalled = false
     var stopCalled = false
 
     func notifyInternalEvent(_ event: SplitInternalEvent) {
+        notifyInternalEvent(event, metadata: nil)
+    }
+
+    func notifyInternalEvent(_ event: SplitInternalEvent, metadata: EventMetadata? = nil) {
+
+        self.metadata = metadata
+
         switch event {
         case .mySegmentsLoadedFromCache:
             mySegmentsLoadedEventFiredCount+=1
@@ -39,8 +47,12 @@ class SplitEventsManagerStub: SplitEventsManager {
         }
     }
 
-    var registeredEvents = [SplitEvent: SplitEventTask]()
-    func register(event: SplitEvent, task: SplitEventTask) {
+    var registeredEvents = [SplitEventWithMetadata: SplitEventActionTask]()
+    func register(event: SplitEvent, task: SplitEventActionTask) {
+        register(event: SplitEventWithMetadata(type: event), task: task)
+    }
+
+    func register(event: SplitEventWithMetadata, task: SplitEventActionTask) {
         registeredEvents[event] = task
     }
 

--- a/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
@@ -35,7 +35,9 @@ class FeatureFlagsSynchronizerStub: FeatureFlagsSynchronizer {
     }
 
     var notifyKilledCalled = false
-    func notifyKilled() {
+    var killedFlag = ""
+    func notifyKilled(flag: String) {
+        killedFlag = flag
         notifyKilledCalled = true
     }
 

--- a/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
@@ -9,7 +9,7 @@ import Foundation
 @testable import Split
 
 class FeatureFlagsSynchronizerStub: FeatureFlagsSynchronizer {
-   var loadCalled = false
+    var loadCalled = false
     func load() {
         loadCalled = true
     }

--- a/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
@@ -40,7 +40,9 @@ class FeatureFlagsSynchronizerStub: FeatureFlagsSynchronizer {
     }
 
     var notifyUpdatedCalled = false
-    func notifyUpdated() {
+    var updatedFlags: [String] = []
+    func notifyUpdated(flagsList: [String]) {
+        updatedFlags = flagsList
         notifyUpdatedCalled = true
     }
 

--- a/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/FeatureFlagsSynchronizerStub.swift
@@ -43,9 +43,16 @@ class FeatureFlagsSynchronizerStub: FeatureFlagsSynchronizer {
 
     var notifyUpdatedCalled = false
     var updatedFlags: [String] = []
-    func notifyUpdated(flagsList: [String]) {
-        updatedFlags = flagsList
+    func notifyUpdated(flags: [String]) {
+        updatedFlags = flags
         notifyUpdatedCalled = true
+    }
+    
+    var notifyUpdatedSegmentsCalled = false
+    var updatedSegments: [String] = []
+    func notifyUpdated(ruleBasedSegments: [String]) {
+        updatedSegments = ruleBasedSegments
+        notifyUpdatedSegmentsCalled = true
     }
 
     var pauseCalled = false

--- a/SplitTests/Fake/Streaming/SynchronizerSpy.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerSpy.swift
@@ -206,7 +206,9 @@ class SynchronizerSpy: Synchronizer {
     }
 
     var notifyFeatureFlagsUpdatedCalled = false
-    func notifyFeatureFlagsUpdated() {
+    var updatedFlags: [String] = []
+    func notifyFeatureFlagsUpdated(flags: [String]) {
+        updatedFlags = flags
         notifyFeatureFlagsUpdatedCalled = true
     }
 

--- a/SplitTests/Fake/Streaming/SynchronizerSpy.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerSpy.swift
@@ -215,6 +215,13 @@ class SynchronizerSpy: Synchronizer {
         updatedFlags = flags
         notifyFeatureFlagsUpdatedCalled = true
     }
+    
+    var notifyRuleBasedSegmentsUpdatedCalled = false
+    var ruleBasedSegmentsUpdated: [String] = []
+    func notifyRuleBasedSegmentsUpdated(segments: [String]) {
+        ruleBasedSegmentsUpdated = segments
+        notifyRuleBasedSegmentsUpdatedCalled = true
+    }
 
     var killedFlag = ""
     func notifySplitKilled(flag: String) {

--- a/SplitTests/Fake/Streaming/SynchronizerSpy.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerSpy.swift
@@ -195,14 +195,18 @@ class SynchronizerSpy: Synchronizer {
         splitSynchronizer.resume()
     }
 
-    func notifySegmentsUpdated(forKey key: String) {
+    var updatedSegmentsMetadataForKey = [String : EventMetadata]()
+    func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
         notifyMySegmentsUpdatedCalled = true
-        splitSynchronizer.notifySegmentsUpdated(forKey: key)
+        updatedSegmentsMetadataForKey[key] = metadata
+        splitSynchronizer.notifySegmentsUpdated(forKey: key, metadata: metadata)
     }
 
-    func notifyLargeSegmentsUpdated(forKey key: String) {
+    var updatedLargeSegmentsMetadataForKey = [String : EventMetadata]()
+    func notifyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
+        updatedLargeSegmentsMetadataForKey[key] = metadata
         notifyMyLargeSegmentsUpdatedCalled = true
-        splitSynchronizer.notifyLargeSegmentsUpdated(forKey: key)
+        splitSynchronizer.notifyLargeSegmentsUpdated(forKey: key, metadata: metadata)
     }
 
     var notifyFeatureFlagsUpdatedCalled = false

--- a/SplitTests/Fake/Streaming/SynchronizerSpy.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerSpy.swift
@@ -212,9 +212,11 @@ class SynchronizerSpy: Synchronizer {
         notifyFeatureFlagsUpdatedCalled = true
     }
 
-    func notifySplitKilled() {
+    var killedFlag = ""
+    func notifySplitKilled(flag: String) {
         notifySplitKilledCalled = true
-        splitSynchronizer.notifySplitKilled()
+        killedFlag = flag
+        splitSynchronizer.notifySplitKilled(flag: flag)
     }
 
     func start(forKey key: Key) {

--- a/SplitTests/Fake/Streaming/SynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerStub.swift
@@ -237,7 +237,9 @@ class SynchronizerStub: Synchronizer {
     }
 
     var notifyFeatureFlagsUpdatedCalled = true
-    func notifyFeatureFlagsUpdated() {
+    var updatedFlags: [String] = []
+    func notifyFeatureFlagsUpdated(flags: [String]) {
+        updatedFlags = flags
         notifyFeatureFlagsUpdatedCalled = true
     }
 

--- a/SplitTests/Fake/Streaming/SynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerStub.swift
@@ -243,7 +243,9 @@ class SynchronizerStub: Synchronizer {
         notifyFeatureFlagsUpdatedCalled = true
     }
 
-    func notifySplitKilled() {
+    var killedFlag = ""
+    func notifySplitKilled(flag: String) {
+        killedFlag = flag
         notifySplitKilledCalled = true
     }
 

--- a/SplitTests/Fake/Streaming/SynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerStub.swift
@@ -16,6 +16,7 @@ struct ForceMySegmentsParams {
 }
 
 class SynchronizerStub: Synchronizer {
+    
     var disableSdkCalled = false
     var disableEventsCalled = false
     var disableTelemetryCalled = false
@@ -246,6 +247,14 @@ class SynchronizerStub: Synchronizer {
         updatedFlags = flags
         notifyFeatureFlagsUpdatedCalled = true
     }
+    
+    var notifyRuleBasedSegmentsUpdatedCalled = true
+    var updatedRuleBasedSegments: [String] = []
+    func notifyRuleBasedSegmentsUpdated(segments: [String]) {
+        updatedRuleBasedSegments = segments
+        notifyRuleBasedSegmentsUpdatedCalled = true
+    }
+    
 
     var killedFlag = ""
     func notifySplitKilled(flag: String) {

--- a/SplitTests/Fake/Streaming/SynchronizerStub.swift
+++ b/SplitTests/Fake/Streaming/SynchronizerStub.swift
@@ -119,16 +119,20 @@ class SynchronizerStub: Synchronizer {
     }
 
     var notifySegmentsUpdatedForKeyCalled = [String: Bool]()
-    func notifySegmentsUpdated(forKey key: String) {
+    var updatedSegmentsMetadataForKey = [String: EventMetadata?]()
+    func notifySegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
         notifySegmentsUpdatedForKeyCalled[key] = true
+        updatedLargeSegmentsMetadataForKey[key] = metadata
         if let exp = notifyMySegmentsUpdatedExp[key] {
             exp.fulfill()
         }
     }
 
     var notifyLargeSegmentsUpdatedForKeyCalled = [String: Bool]()
-    func notifyLargeSegmentsUpdated(forKey key: String) {
+    var updatedLargeSegmentsMetadataForKey = [String: EventMetadata?]()
+    func notifyLargeSegmentsUpdated(forKey key: String, metadata: EventMetadata? = nil) {
         notifyLargeSegmentsUpdatedForKeyCalled[key] = true
+        updatedLargeSegmentsMetadataForKey[key] = metadata
         if let exp = notifyMyLargeSegmentsUpdatedExp[key] {
             exp.fulfill()
         }

--- a/SplitTests/Helpers/IntegrationHelper.swift
+++ b/SplitTests/Helpers/IntegrationHelper.swift
@@ -227,6 +227,8 @@ class IntegrationHelper {
             return "myLargeSegmentsUpdated"
         case .myLargeSegmentsLoadedFromCache:
             return "myLargeSegmentsLoadedFromCache"
+        case .ruleBasedSegmentsUpdated:
+            return "ruleBasedSegmentsUpdated"
         }
     }
 

--- a/SplitTests/Helpers/TestingHelper.swift
+++ b/SplitTests/Helpers/TestingHelper.swift
@@ -214,7 +214,7 @@ struct TestingHelper {
     static func buildSegmentsChange(count: Int64 = 5,
                                     msAscOrder: Bool = true,
                                     mlsAscOrder: Bool = true,
-                                    segmentsChanged: Bool = false) -> [AllSegmentsChange] {
+                                    segmentsChanged: [String] = []) -> [AllSegmentsChange] {
         // Eventualy cn will be greater than the first
         let baseCn: Int64 = 100
         let lastMsCn = baseCn * count + 1
@@ -233,10 +233,13 @@ struct TestingHelper {
             res.append(newAllSegmentsChange(ms: msSeg, msCn: msC,
                                             mls: mlsSeg, mlsCn: mlsC))
         }
-        if segmentsChanged {
-            msSeg.append("s3")
-            mlsSeg.append("sl3")
+        if !segmentsChanged.isEmpty {
+            segmentsChanged.forEach { segment in
+                msSeg.append(segment)
+            }
         }
+        msSeg.append("s3")
+        mlsSeg.append("sl3")
         res.append(newAllSegmentsChange(ms: msSeg, msCn: lastMsCn,
                                         mls: mlsSeg, mlsCn: lastMlsCn))
 
@@ -261,7 +264,7 @@ struct TestingHelper {
 
     static func segmentsSyncResult(_ result: Bool = true,
                                    msCn: Int64 = 300, mlsCn: Int64 = 400,
-                                   msUpd: Bool = true, mlsUpd: Bool = true) -> SegmentsSyncResult {
+                                   msUpd: [String] = ["SegmentTest1"], mlsUpd: [String] = ["LargeSegmentTest1"]) -> SegmentsSyncResult {
         return SegmentsSyncResult(success: result,
                                   msChangeNumber: msCn, mlsChangeNumber: mlsCn,
                                   msUpdated: msUpd, mlsUpdated: mlsUpd)

--- a/SplitTests/Helpers/TestingHelper.swift
+++ b/SplitTests/Helpers/TestingHelper.swift
@@ -215,6 +215,7 @@ struct TestingHelper {
                                     msAscOrder: Bool = true,
                                     mlsAscOrder: Bool = true,
                                     segmentsChanged: [String] = []) -> [AllSegmentsChange] {
+
         // Eventualy cn will be greater than the first
         let baseCn: Int64 = 100
         let lastMsCn = baseCn * count + 1

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -34,15 +34,15 @@ class SplitSdkUpdatePollingTest: XCTestCase {
     
     override func setUp() {
         let session = HttpSessionMock()
-        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(),
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher("splitchanges_int_test"),
                                                           streamingHandler: buildStreamingHandler())
         httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
     }
 
     
-    private func buildTestDispatcher() -> HttpClientTestDispatcher {
+    private func buildTestDispatcher(_ file: String) -> HttpClientTestDispatcher {
 
-        let respData = responseSplitChanges()
+        let respData = responseSplitChanges(file)
         var responses = [TestDispatcherResponse]()
         for data in respData {
             let rData = TargetingRulesChange(featureFlags: data, ruleBasedSegments: RuleBasedSegmentChange(segments: [], since: -1, till: -1))
@@ -307,12 +307,12 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         semaphore.wait()
     }
 
-    private func  responseSplitChanges() -> [SplitChange] {
+    private func  responseSplitChanges(_ file: String) -> [SplitChange] {
         var changes = [SplitChange]()
 
         var prevChangeNumber: Int64 = 0
         for i in 0..<4 {
-            let c = loadSplitsChangeFile()!
+            let c = loadSplitsChangeFile(file)!
             c.since = c.till
             if prevChangeNumber != 0 {
                 c.till = prevChangeNumber  + kChangeNbInterval
@@ -331,8 +331,8 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         return changes
     }
 
-    private func loadSplitsChangeFile() -> SplitChange? {
-        return FileHelper.loadSplitChangeFile(sourceClass: self, fileName: "splitchanges_int_test")
+    private func loadSplitsChangeFile(_ file: String) -> SplitChange? {
+        return FileHelper.loadSplitChangeFile(sourceClass: self, fileName: file)
     }
 
     private func getAndIncrement() -> Int {

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -207,6 +207,50 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         })
         semaphore.wait()
     }
+    
+    func testSdkUpdateSplitsWithMetadata() throws {
+        let apiKey = IntegrationHelper.dummyApiKey
+        let trafficType = "client"
+
+        let sdkReady = XCTestExpectation(description: "SDK READY Expectation")
+        let sdkUpdateWithMetadata = XCTestExpectation(description: "SDK Update With Metadata Expectation")
+
+        let splitConfig: SplitClientConfig = SplitClientConfig()
+        splitConfig.segmentsRefreshRate = 99999
+        splitConfig.featuresRefreshRate = 2
+        splitConfig.impressionRefreshRate = 99999
+        splitConfig.sdkReadyTimeOut = 60000
+        splitConfig.trafficType = trafficType
+        splitConfig.streamingEnabled = false
+        splitConfig.serviceEndpoints = ServiceEndpoints.builder()
+        .set(sdkEndpoint: serverUrl).set(eventsEndpoint: serverUrl).build()
+
+        let key: Key = Key(matchingKey: kMatchingKey, bucketingKey: nil)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setTestDatabase(TestingHelper.createTestDatabase(name: "SplitChangesTest"))
+        _ = builder.setHttpClient(httpClient)
+        factory = builder.setApiKey(apiKey).setKey(key).setConfig(splitConfig).build()
+
+        let client = factory!.client
+
+        client.on(event: .sdkReady) {
+            sdkReady.fulfill()
+        }
+
+        client.on(event: .sdkUpdated) { metadata in
+            XCTAssertEqual(metadata?.type, .FLAGS_UPDATED)
+            XCTAssertEqual(metadata?.data, ["test_feature"])
+            sdkUpdateWithMetadata.fulfill()
+        }
+
+        wait(for: [sdkReady, sdkUpdateWithMetadata], timeout: 30)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        client.destroy(completion: {
+            _ = semaphore.signal()
+        })
+        semaphore.wait()
+    }
 
     func testSdkUpdateMySegments() throws {
         let apiKey = IntegrationHelper.dummyApiKey

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -29,87 +29,21 @@ class SplitSdkUpdatePollingTest: XCTestCase {
     ]
 
     let impExp = XCTestExpectation(description: "impressions")
-
     var impHit: [ImpressionsTest]?
     
     override func setUp() {
         let session = HttpSessionMock()
-        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher("splitchanges_int_test"),
-                                                          streamingHandler: buildStreamingHandler())
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: buildTestDispatcher(), streamingHandler: buildStreamingHandler())
         httpClient = DefaultHttpClient(session: session, requestManager: reqManager)
     }
 
-    
-    private func buildTestDispatcher(_ file: String) -> HttpClientTestDispatcher {
-
-        let respData = responseSplitChanges(file)
-        var responses = [TestDispatcherResponse]()
-        for data in respData {
-            let rData = TargetingRulesChange(featureFlags: data, ruleBasedSegments: RuleBasedSegmentChange(segments: [], since: -1, till: -1))
-            responses.append(TestDispatcherResponse(code: 200, data: Data(try! Json.encodeToJson(rData).utf8)))
-        }
-
-        return { request in
-            if request.isSplitEndpoint() {
-                let index = self.getAndIncrement()
-                if index < self.spExp.count {
-                    if index > 0 {
-                        self.spExp[index - 1].fulfill()
-                    }
-                    return responses[index]
-                } else if index == self.spExp.count {
-                    self.spExp[index - 1].fulfill()
-                }
-                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptySplitChanges(since: 99999999, till: 99999999).utf8))
-            }
-
-            if request.isMySegmentsEndpoint() {
-                self.mySegmentsHits+=1
-                let hit = self.mySegmentsHits
-                var json = IntegrationHelper.emptyMySegments
-                if hit > 2 {
-                    var mySegments = [String]()
-                    for i in 1...hit {
-                        mySegments.append("segment\(i)")
-                    }
-
-                    json = IntegrationHelper.buildSegments(regular: mySegments)
-                    return TestDispatcherResponse(code: 200, data: Data(json.utf8))
-                }
-                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
-            }
-
-            if request.isAuthEndpoint() {
-                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.dummySseResponse().utf8))
-            }
-
-            if request.isImpressionsEndpoint() {
-                self.impHit = try? TestUtils.impressionsFromHit(request: request)
-                self.impExp.fulfill()
-                return TestDispatcherResponse(code: 200)
-            }
-
-            if request.isEventsEndpoint() {
-                return TestDispatcherResponse(code: 200)
-            }
-
-            return TestDispatcherResponse(code: 500)
-        }
-    }
-
-    private func buildStreamingHandler() -> TestStreamResponseBindingHandler {
-        return { request in
-            self.streamingBinding = TestStreamResponseBinding.createFor(request: request, code: 200)
-            return self.streamingBinding!
-        }
-    }
-
-    // MARK: Test
+    // MARK: Tests
     func testSdkReadyOnly() throws {
         let apiKey = IntegrationHelper.dummyApiKey
         let trafficType = "client"
 
         let sdkReady = XCTestExpectation(description: "SDK READY Expectation")
+        let sdkUpdate = XCTestExpectation(description: "SDK UPDATE Expectation")
         
         let splitConfig: SplitClientConfig = SplitClientConfig()
         splitConfig.segmentsRefreshRate = 99999
@@ -139,6 +73,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
 
         client.on(event: SplitEvent.sdkUpdated) {
             sdkUpdatedFired = true
+            sdkUpdate.fulfill()
         }
         
         wait(for: [sdkReady], timeout: 30)
@@ -212,7 +147,6 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         let apiKey = IntegrationHelper.dummyApiKey
         let trafficType = "client"
 
-        let sdkReady = XCTestExpectation(description: "SDK READY Expectation")
         let sdkUpdateWithMetadata = XCTestExpectation(description: "SDK Update With Metadata Expectation")
 
         let splitConfig: SplitClientConfig = SplitClientConfig()
@@ -233,17 +167,13 @@ class SplitSdkUpdatePollingTest: XCTestCase {
 
         let client = factory!.client
 
-        client.on(event: .sdkReady) {
-            sdkReady.fulfill()
-        }
-
         client.on(event: .sdkUpdated) { metadata in
             XCTAssertEqual(metadata?.type, .FLAGS_UPDATED)
             XCTAssertEqual(metadata?.data, ["test_feature"])
             sdkUpdateWithMetadata.fulfill()
         }
 
-        wait(for: [sdkReady, sdkUpdateWithMetadata], timeout: 30)
+        wait(for: [sdkUpdateWithMetadata], timeout: 30)
 
         let semaphore = DispatchSemaphore(value: 0)
         client.destroy(completion: {
@@ -251,7 +181,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         })
         semaphore.wait()
     }
-
+    
     func testSdkUpdateMySegments() throws {
         let apiKey = IntegrationHelper.dummyApiKey
         let trafficType = "client"
@@ -307,12 +237,121 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         semaphore.wait()
     }
 
-    private func  responseSplitChanges(_ file: String) -> [SplitChange] {
+    func testSdkUpdateMySegmentsWithMetadata() throws {
+        let apiKey = IntegrationHelper.dummyApiKey
+        let trafficType = "client"
+
+        let sdkReady = XCTestExpectation(description: "SDK READY Expectation")
+        let sdkUpdateWithMetadata = XCTestExpectation(description: "SDK Update With Metadata Expectation")
+
+        let splitConfig: SplitClientConfig = SplitClientConfig()
+        splitConfig.segmentsRefreshRate = 2
+        splitConfig.featuresRefreshRate = 999999
+        splitConfig.impressionRefreshRate = 999999
+        splitConfig.sdkReadyTimeOut = 60000
+        splitConfig.trafficType = trafficType
+        splitConfig.streamingEnabled = false
+        splitConfig.logLevel = .verbose
+        splitConfig.serviceEndpoints = ServiceEndpoints.builder()
+        .set(sdkEndpoint: serverUrl).set(eventsEndpoint: serverUrl).build()
+
+        let key: Key = Key(matchingKey: kMatchingKey, bucketingKey: nil)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setTestDatabase(TestingHelper.createTestDatabase(name: "SplitChangesTest"))
+        _ = builder.setHttpClient(httpClient)
+        factory = builder.setApiKey(apiKey).setKey(key).setConfig(splitConfig).build()
+        let client = factory!.client
+        
+        client.on(event: .sdkUpdated) { metadata in
+            if metadata?.type == .SEGMENTS_UPDATED {
+                XCTAssertEqual(metadata?.data, ["segment1", "segment2", "segment3"])
+                sdkUpdateWithMetadata.fulfill()
+            }
+        }
+
+        wait(for: [sdkUpdateWithMetadata], timeout: 40)
+
+        // wait for sdk update
+        ThreadUtils.delay(seconds: 1.0)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        client.destroy(completion: {
+            _ = semaphore.signal()
+        })
+        semaphore.wait()
+    }
+
+    //MARK:  Testing Helpers
+    private func buildTestDispatcher() -> HttpClientTestDispatcher {
+
+        let respData = responseSplitChanges()
+        var responses = [TestDispatcherResponse]()
+        for data in respData {
+            let rData = TargetingRulesChange(featureFlags: data, ruleBasedSegments: RuleBasedSegmentChange(segments: [], since: -1, till: -1))
+            responses.append(TestDispatcherResponse(code: 200, data: Data(try! Json.encodeToJson(rData).utf8)))
+        }
+
+        return { request in
+            if request.isSplitEndpoint() {
+                let index = self.getAndIncrement()
+                if index < self.spExp.count {
+                    if index > 0 {
+                        self.spExp[index - 1].fulfill()
+                    }
+                    return responses[index]
+                } else if index == self.spExp.count {
+                    self.spExp[index - 1].fulfill()
+                }
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptySplitChanges(since: 99999999, till: 99999999).utf8))
+            }
+
+            if request.isMySegmentsEndpoint() {
+                self.mySegmentsHits+=1
+                let hit = self.mySegmentsHits
+                var json = IntegrationHelper.emptyMySegments
+                if hit > 2 {
+                    var mySegments = [String]()
+                    for i in 1...hit {
+                        mySegments.append("segment\(i)")
+                    }
+
+                    json = IntegrationHelper.buildSegments(regular: mySegments)
+                    return TestDispatcherResponse(code: 200, data: Data(json.utf8))
+                }
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
+            }
+
+            if request.isAuthEndpoint() {
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.dummySseResponse().utf8))
+            }
+
+            if request.isImpressionsEndpoint() {
+                self.impHit = try? TestUtils.impressionsFromHit(request: request)
+                self.impExp.fulfill()
+                return TestDispatcherResponse(code: 200)
+            }
+
+            if request.isEventsEndpoint() {
+                return TestDispatcherResponse(code: 200)
+            }
+
+            return TestDispatcherResponse(code: 500)
+        }
+    }
+
+    private func buildStreamingHandler() -> TestStreamResponseBindingHandler {
+        return { request in
+            self.streamingBinding = TestStreamResponseBinding.createFor(request: request, code: 200)
+            return self.streamingBinding!
+        }
+    }
+    
+    private func  responseSplitChanges() -> [SplitChange] {
         var changes = [SplitChange]()
 
         var prevChangeNumber: Int64 = 0
         for i in 0..<4 {
-            let c = loadSplitsChangeFile(file)!
+            let c = loadSplitsChangeFile()!
             c.since = c.till
             if prevChangeNumber != 0 {
                 c.till = prevChangeNumber  + kChangeNbInterval
@@ -331,8 +370,8 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         return changes
     }
 
-    private func loadSplitsChangeFile(_ file: String) -> SplitChange? {
-        return FileHelper.loadSplitChangeFile(sourceClass: self, fileName: file)
+    private func loadSplitsChangeFile() -> SplitChange? {
+        return FileHelper.loadSplitChangeFile(sourceClass: self, fileName: "splitchanges_int_test")
     }
 
     private func getAndIncrement() -> Int {

--- a/SplitTests/Service/MySegments/SegmentsSyncHelperTests.swift
+++ b/SplitTests/Service/MySegments/SegmentsSyncHelperTests.swift
@@ -40,18 +40,19 @@ class SegmentsSyncHelperTests: XCTestCase {
     }
 
     func testCdnByPassNoTillNoChange() throws {
-        try cdnByPassNoTill(segmentsChanged: false)
+        try cdnByPassNoTill(segmentsChanged: [])
     }
 
     func testCdnByPassNoTillChange() throws {
-        try cdnByPassNoTill(segmentsChanged: true)
+        try cdnByPassNoTill(segmentsChanged: ["Segment1"])
     }
 
-    func cdnByPassNoTill(segmentsChanged: Bool) throws {
+    func cdnByPassNoTill(segmentsChanged: [String]) throws {
         let goalCn: Int64 = 300
         mySegmentsStorage.changeNumber = 200
         myLargeSegmentsStorage.changeNumber = 200
-        changeChecker.haveChanged = segmentsChanged
+        changeChecker.haveChanged = !segmentsChanged.isEmpty
+        changeChecker.diffSegments = segmentsChanged
 
         let exp = XCTestExpectation()
         mySegmentsFetcher.countExp = exp

--- a/SplitTests/SplitEventsManagerTest.swift
+++ b/SplitTests/SplitEventsManagerTest.swift
@@ -268,11 +268,11 @@ class SplitEventsManagerTest: XCTestCase {
         let taskExp = XCTestExpectation()
         
         // Build Task
-        let metadata = EventMetadata(type: .FLAGS_KILLED, data: "TEST_FLAG")
+        let metadata = EventMetadata(type: .FLAGS_KILLED, data: ["TEST_FLAG"])
         
         let handler: SplitActionWithMetadata = { handlerMetadata in
             XCTAssertEqual(metadata.type, handlerMetadata?.type)
-            XCTAssertEqual(metadata.data, "TEST_FLAG")
+            XCTAssertEqual(metadata.data, ["TEST_FLAG"])
             taskExp.fulfill()
         }
         let task = SplitEventActionTask(action: handler, event: .sdkReady, runInBackground: false, factory: SplitFactoryStub(apiKey: IntegrationHelper.dummyApiKey), queue: nil)
@@ -319,7 +319,7 @@ class SplitEventsManagerTest: XCTestCase {
 
         // Dummy event with metadata
         let metadataTypeToCheck: EventMetadataType = .FLAGS_KILLED
-        let metadataDataToCheck: String            = "Test-flag-42"
+        let metadataDataToCheck: [String]            = ["Test-flag-42"]
         let dummyMetadata = EventMetadata(type: metadataTypeToCheck, data: metadataDataToCheck)
 
         // This will be the task's "run()"

--- a/SplitTests/Streaming/FeatureFlagsSynchronizerTest.swift
+++ b/SplitTests/Streaming/FeatureFlagsSynchronizerTest.swift
@@ -260,7 +260,7 @@ class FeatureFlagsSynchronizerTest: XCTestCase {
     }
     
     func testMetadataOnFeatureFlagsSync() {
-        synchronizer.notifyUpdated(flagsList: ["Pepe2"])
+        synchronizer.notifyUpdated(flags: ["Pepe2"])
         
         XCTAssertEqual(eventsManager.metadata?.type, .FLAGS_UPDATED)
         XCTAssertEqual(eventsManager.metadata?.data, ["Pepe2"])

--- a/SplitTests/Streaming/FeatureFlagsSynchronizerTest.swift
+++ b/SplitTests/Streaming/FeatureFlagsSynchronizerTest.swift
@@ -258,6 +258,13 @@ class FeatureFlagsSynchronizerTest: XCTestCase {
         XCTAssertTrue(persistentSplitsStorage.clearCalled)
         XCTAssertEqual(1, broadcasterChannel.pushedEvents.filter { $0 == .splitLoadedFromCache }.count)
     }
+    
+    func testMetadataOnFeatureFlagsSync() {
+        synchronizer.notifyUpdated(flagsList: ["Pepe2"])
+        
+        XCTAssertEqual(eventsManager.metadata?.type, .FLAGS_UPDATED)
+        XCTAssertEqual(eventsManager.metadata?.data, ["Pepe2"])
+    }
 
     func testSynchronizeSplitsWithChangeNumber() {
 

--- a/SplitTests/Streaming/SynchronizerTest.swift
+++ b/SplitTests/Streaming/SynchronizerTest.swift
@@ -223,6 +223,20 @@ class SynchronizerTest: XCTestCase {
 
         XCTAssertTrue(byKeyApiFacade.startSyncForKeyCalled[key] ?? false)
     }
+    
+    func testMetadataOnSegmentsByKeySync() {
+        let metadata = EventMetadata(type: .FLAGS_UPDATED, data: ["Carlos", "Juancho"])
+        synchronizer.notifySegmentsUpdated(forKey: "4", metadata: metadata)
+        
+        XCTAssertEqual(byKeyApiFacade.updatedSegmentsMetadataForKey["4"], metadata)
+    }
+    
+    func testMetadataOnLargeSegmentsByKeySync() {
+        let metadata = EventMetadata(type: .FLAGS_UPDATED, data: ["Lagarto", "Juancho"])
+        synchronizer.notifySegmentsUpdated(forKey: "5", metadata: metadata)
+        
+        XCTAssertEqual(byKeyApiFacade.updatedSegmentsMetadataForKey["5"], metadata)
+    }
 
     func testFlush() {
 


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
SplitEvent and SplitInternalEvent are going to be wrapped in new objects that can carry metadata.

## How do we test the changes introduced in this PR?

## Extra Notes
SonarQube is not passing because its finding code not covered, but its just entities (not logic).