### PR TITLE
Fix/segments count

### DIFF
--- a/Split/Api/SplitDatabaseHelper.swift
+++ b/Split/Api/SplitDatabaseHelper.swift
@@ -103,7 +103,8 @@ struct SplitDatabaseHelper {
         let flagSetsCache: FlagSetsCache =
         DefaultFlagSetsCache(setsInFilter: splitClientConfig.bySetsFilter()?.values.asSet())
         let persistentSplitsStorage = DefaultPersistentSplitsStorage(database: splitDatabase)
-        let splitsStorage = openSplitsStorage(database: splitDatabase, flagSetsCache: flagSetsCache)
+        let generalInfoStorage = openGeneralInfoStorage(database: splitDatabase)
+        let splitsStorage = openSplitsStorage(database: splitDatabase, flagSetsCache: flagSetsCache, generalInfoStorage: generalInfoStorage)
 
         let persistentImpressionsStorage = openPersistentImpressionsStorage(database: splitDatabase)
         let impressionsStorage = openImpressionsStorage(persistentStorage: persistentImpressionsStorage)
@@ -111,8 +112,6 @@ struct SplitDatabaseHelper {
 
         let persistentEventsStorage = openPersistentEventsStorage(database: splitDatabase)
         let eventsStorage = openEventsStorage(persistentStorage: persistentEventsStorage)
-        
-        let generalInfoStorage = openGeneralInfoStorage(database: splitDatabase)
 
         let mySegmentsStorage = openMySegmentsStorage(database: splitDatabase, generalInfoStorage: generalInfoStorage)
         let myLargeSegmentsStorage = openMyLargeSegmentsStorage(database: splitDatabase, generalInfoStorage: generalInfoStorage)
@@ -133,7 +132,7 @@ struct SplitDatabaseHelper {
             generalInfoStorage: generalInfoStorage)
 
         let ruleBasedSegmentsStorage = DefaultRuleBasedSegmentsStorage(
-            persistentStorage: persistentRuleBasedSegmentsStorage)
+            persistentStorage: persistentRuleBasedSegmentsStorage, generalInfoStorage: generalInfoStorage)
 
         return SplitStorageContainer(splitDatabase: splitDatabase,
                                      splitsStorage: splitsStorage,
@@ -175,9 +174,9 @@ struct SplitDatabaseHelper {
     }
 
     static func openSplitsStorage(database: SplitDatabase,
-                                  flagSetsCache: FlagSetsCache) -> SplitsStorage {
+                                  flagSetsCache: FlagSetsCache, generalInfoStorage: GeneralInfoStorage) -> SplitsStorage {
         return DefaultSplitsStorage(persistentSplitsStorage: openPersistentSplitsStorage(database: database),
-                                    flagSetsCache: flagSetsCache)
+                                    flagSetsCache: flagSetsCache, GeneralInfoStorage: generalInfoStorage)
     }
 
     static func openPersistentMySegmentsStorage(database: SplitDatabase) -> PersistentMySegmentsStorage {

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -148,7 +148,6 @@ class DefaultSplitEventsManager: SplitEventsManager {
             self.triggered.append(event)
             switch event {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
-                print("*********** EVENT !! **************\n\(event)\n*********** EVENT !! **************")
                 if isTriggered(external: .sdkReady) {
                     trigger(event: .sdkUpdated)
                     continue

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -148,7 +148,9 @@ class DefaultSplitEventsManager: SplitEventsManager {
             self.triggered.append(event)
             switch event {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
+                print("                    EVENT !! **************\n\(event)\n              EVENT !! **************")
                 if isTriggered(external: .sdkReady) {
+                    print("                    SDK UPDATED          ")
                     trigger(event: .sdkUpdated)
                     continue
                 }
@@ -197,6 +199,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
             if !isTriggered(external: .sdkReadyFromCache) {
                 self.trigger(event: .sdkReadyFromCache)
             }
+            print("    --------- *** TRIGGER READy")
             self.trigger(event: .sdkReady)
         }
     }

--- a/Split/Events/SplitEventsManager.swift
+++ b/Split/Events/SplitEventsManager.swift
@@ -148,6 +148,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
             self.triggered.append(event)
             switch event {
             case .splitsUpdated, .mySegmentsUpdated, .myLargeSegmentsUpdated:
+                print("*********** EVENT !! **************\n\(event)\n*********** EVENT !! **************")
                 if isTriggered(external: .sdkReady) {
                     trigger(event: .sdkUpdated)
                     continue
@@ -181,7 +182,7 @@ class DefaultSplitEventsManager: SplitEventsManager {
         var triggered = false
         dataAccessQueue.sync {
             if let times = executionTimes[event.toString()] {
-                triggered =  (times == 0)
+                triggered = (times == 0)
             } else {
                 triggered = false
             }

--- a/Split/FetcherEngine/Refresh/BackgroundSyncWorker.swift
+++ b/Split/FetcherEngine/Refresh/BackgroundSyncWorker.swift
@@ -57,7 +57,8 @@ class BackgroundSplitsSyncWorker: BackgroundSyncWorker {
          splitChangeProcessor: SplitChangeProcessor,
          ruleBasedSegmentsChangeProcessor: RuleBasedSegmentChangeProcessor,
          cacheExpiration: Int64,
-         splitConfig: SplitClientConfig) {
+         splitConfig: SplitClientConfig,
+         generalInfoStorage: GeneralInfoStorage) {
 
         self.persistenSplitsStorage = persistentSplitsStorage
         self.persistentRuleBasedSegmentsStorage = persistentRuleBasedSegmentsStorage
@@ -66,7 +67,7 @@ class BackgroundSplitsSyncWorker: BackgroundSyncWorker {
         self.cacheExpiration = cacheExpiration
         self.syncHelper = SplitsSyncHelper(splitFetcher: splitFetcher,
                                            splitsStorage: BackgroundSyncSplitsStorage(persistentSplitsStorage: persistentSplitsStorage),
-                                           ruleBasedSegmentsStorage: DefaultRuleBasedSegmentsStorage(persistentStorage: persistentRuleBasedSegmentsStorage),
+                                           ruleBasedSegmentsStorage: DefaultRuleBasedSegmentsStorage(persistentStorage: persistentRuleBasedSegmentsStorage, generalInfoStorage: generalInfoStorage),
                                            splitChangeProcessor: splitChangeProcessor,
                                            ruleBasedSegmentsChangeProcessor: ruleBasedSegmentsChangeProcessor,
                                            generalInfoStorage: nil, // Pass nil to disable proxy handling for background sync

--- a/Split/FetcherEngine/Refresh/SplitBgSynchronizer.swift
+++ b/Split/FetcherEngine/Refresh/SplitBgSynchronizer.swift
@@ -198,7 +198,8 @@ struct BackgroundSyncExecutor {
                                                            splitChangeProcessor: changeProcessor,
                                                            ruleBasedSegmentsChangeProcessor: ruleBasedSegmentChangeProcessor,
                                                            cacheExpiration: cacheExpiration,
-                                                           splitConfig: SplitClientConfig())
+                                                           splitConfig: SplitClientConfig(),
+                                                           generalInfoStorage: generalInfoStorage)
 
         let impressionsRecorder
             = DefaultHttpImpressionsRecorder(restClient: restClient,

--- a/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
+++ b/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
@@ -27,7 +27,7 @@ class SplitsSyncHelper {
 
     private let splitFetcher: HttpSplitFetcher
     private let splitsStorage: SyncSplitsStorage
-    private let ruleBasedSegmentsStorage: RuleBasedSegmentsStorage
+    private var ruleBasedSegmentsStorage: RuleBasedSegmentsStorage
     private let splitChangeProcessor: SplitChangeProcessor
     private let ruleBasedSegmentsChangeProcessor: RuleBasedSegmentChangeProcessor
     private let splitConfig: SplitClientConfig
@@ -202,11 +202,13 @@ class SplitsSyncHelper {
                 ruleBasedSegmentsStorage.clear()
             }
             firstFetch = false
+            
             if splitsStorage.update(splitChange: splitChangeProcessor.process(targetingRulesChange.featureFlags)) {
                 featureFlagsUpdated = true
             }
             
             let processedChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)
+            ruleBasedSegmentsStorage.segmentsInUse = splitsStorage.getSegmentsInUse()
             if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd, toRemove: processedChange.toRemove, changeNumber: processedChange.changeNumber) {
                 rbsUpdated = true
             }

--- a/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
+++ b/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
@@ -208,7 +208,6 @@ class SplitsSyncHelper {
             }
             
             let processedChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)
-            //ruleBasedSegmentsStorage.segmentsInUse = splitsStorage.getSegmentsInUse()
             if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd, toRemove: processedChange.toRemove, changeNumber: processedChange.changeNumber) {
                 rbsUpdated = true
             }

--- a/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
+++ b/Split/FetcherEngine/Refresh/SplitsSyncHelper.swift
@@ -208,7 +208,7 @@ class SplitsSyncHelper {
             }
             
             let processedChange = ruleBasedSegmentsChangeProcessor.process(targetingRulesChange.ruleBasedSegments)
-            ruleBasedSegmentsStorage.segmentsInUse = splitsStorage.getSegmentsInUse()
+            //ruleBasedSegmentsStorage.segmentsInUse = splitsStorage.getSegmentsInUse()
             if ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd, toRemove: processedChange.toRemove, changeNumber: processedChange.changeNumber) {
                 rbsUpdated = true
             }

--- a/Split/Localhost/LocalhostSplitsStorage.swift
+++ b/Split/Localhost/LocalhostSplitsStorage.swift
@@ -9,12 +9,11 @@
 import Foundation
 
 class LocalhostSplitsStorage: SplitsStorage {
-
     var changeNumber: Int64 = -1
     var updateTimestamp: Int64 = 1
     var splitsFilterQueryString: String = ""
     var flagsSpec: String = ""
-    internal var segmentsInUse: Int64 = 0
+    var segmentsInUse: Int64 = 0
 
     private let inMemorySplits = ConcurrentDictionary<String, Split>()
 
@@ -47,6 +46,10 @@ class LocalhostSplitsStorage: SplitsStorage {
         inMemorySplits.removeAll()
         inMemorySplits.setValues(values)
         return true
+    }
+    
+    func getSegmentsInUse() -> Int64 {
+        segmentsInUse
     }
 
     func update(filterQueryString: String) {

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -101,22 +101,22 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a targeting rule update notification and return true if successful
     private func processTargetingRuleUpdate(notification: TargetingRuleUpdateNotification,
-                                            payload: String,
-                                            compressionType: CompressionType,
-                                            previousChangeNumber: Int64) -> Bool {
+                                           payload: String,
+                                           compressionType: CompressionType,
+                                           previousChangeNumber: Int64) -> Bool {
 
         switch notification.type {
         case .splitUpdate:
             return processSplitUpdate(payload: payload,
-                                      compressionType: compressionType,
-                                      previousChangeNumber: previousChangeNumber,
-                                      changeNumber: notification.changeNumber)
+                                     compressionType: compressionType,
+                                     previousChangeNumber: previousChangeNumber,
+                                     changeNumber: notification.changeNumber)
 
         case .ruleBasedSegmentUpdate:
             return processRuleBasedSegmentUpdate(payload: payload,
-                                                 compressionType: compressionType,
-                                                 previousChangeNumber: previousChangeNumber,
-                                                 changeNumber: notification.changeNumber)
+                                               compressionType: compressionType,
+                                               previousChangeNumber: previousChangeNumber,
+                                               changeNumber: notification.changeNumber)
 
         default:
             return false
@@ -125,9 +125,9 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a split update notification
     private func processSplitUpdate(payload: String,
-                                    compressionType: CompressionType,
-                                    previousChangeNumber: Int64,
-                                    changeNumber: Int64) -> Bool {
+                                   compressionType: CompressionType,
+                                   previousChangeNumber: Int64,
+                                   changeNumber: Int64) -> Bool {
         do {
             let split = try self.payloadDecoder.decode(
                 payload: payload,
@@ -157,9 +157,9 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a rule-based segment update notification
     private func processRuleBasedSegmentUpdate(payload: String,
-                                               compressionType: CompressionType,
-                                               previousChangeNumber: Int64,
-                                               changeNumber: Int64) -> Bool {
+                                             compressionType: CompressionType,
+                                             previousChangeNumber: Int64,
+                                             changeNumber: Int64) -> Bool {
         do {
             let rbs = try self.ruleBasedSegmentsPayloadDecoder.decode(
                 payload: payload,
@@ -174,8 +174,8 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
             let processedChange = ruleBasedSegmentsChangeProcessor.process(change)
 
             if self.ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
-                                                    toRemove: processedChange.toRemove,
-                                                    changeNumber: processedChange.changeNumber) {
+                                                  toRemove: processedChange.toRemove,
+                                                  changeNumber: processedChange.changeNumber) {
                 self.synchronizer.notifyFeatureFlagsUpdated()
             }
 

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -101,22 +101,22 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a targeting rule update notification and return true if successful
     private func processTargetingRuleUpdate(notification: TargetingRuleUpdateNotification,
-                                           payload: String,
-                                           compressionType: CompressionType,
-                                           previousChangeNumber: Int64) -> Bool {
+                                            payload: String,
+                                            compressionType: CompressionType,
+                                            previousChangeNumber: Int64) -> Bool {
 
         switch notification.type {
         case .splitUpdate:
             return processSplitUpdate(payload: payload,
-                                     compressionType: compressionType,
-                                     previousChangeNumber: previousChangeNumber,
-                                     changeNumber: notification.changeNumber)
+                                      compressionType: compressionType,
+                                      previousChangeNumber: previousChangeNumber,
+                                      changeNumber: notification.changeNumber)
 
         case .ruleBasedSegmentUpdate:
             return processRuleBasedSegmentUpdate(payload: payload,
-                                               compressionType: compressionType,
-                                               previousChangeNumber: previousChangeNumber,
-                                               changeNumber: notification.changeNumber)
+                                                 compressionType: compressionType,
+                                                 previousChangeNumber: previousChangeNumber,
+                                                 changeNumber: notification.changeNumber)
 
         default:
             return false
@@ -125,9 +125,9 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a split update notification
     private func processSplitUpdate(payload: String,
-                                   compressionType: CompressionType,
-                                   previousChangeNumber: Int64,
-                                   changeNumber: Int64) -> Bool {
+                                    compressionType: CompressionType,
+                                    previousChangeNumber: Int64,
+                                    changeNumber: Int64) -> Bool {
         do {
             let split = try self.payloadDecoder.decode(
                 payload: payload,
@@ -157,9 +157,9 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
 
     /// Process a rule-based segment update notification
     private func processRuleBasedSegmentUpdate(payload: String,
-                                             compressionType: CompressionType,
-                                             previousChangeNumber: Int64,
-                                             changeNumber: Int64) -> Bool {
+                                               compressionType: CompressionType,
+                                               previousChangeNumber: Int64,
+                                               changeNumber: Int64) -> Bool {
         do {
             let rbs = try self.ruleBasedSegmentsPayloadDecoder.decode(
                 payload: payload,
@@ -174,8 +174,8 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
             let processedChange = ruleBasedSegmentsChangeProcessor.process(change)
 
             if self.ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
-                                                  toRemove: processedChange.toRemove,
-                                                  changeNumber: processedChange.changeNumber) {
+                                                    toRemove: processedChange.toRemove,
+                                                    changeNumber: processedChange.changeNumber) {
                 self.synchronizer.notifyFeatureFlagsUpdated()
             }
 

--- a/Split/Network/Streaming/SyncUpdateWorker.swift
+++ b/Split/Network/Streaming/SyncUpdateWorker.swift
@@ -172,7 +172,6 @@ class SplitsUpdateWorker: UpdateWorker<TargetingRuleUpdateNotification> {
             Logger.v("RBS update received: \(change)")
 
             let processedChange = ruleBasedSegmentsChangeProcessor.process(change)
-
             if self.ruleBasedSegmentsStorage.update(toAdd: processedChange.toAdd,
                                                   toRemove: processedChange.toRemove,
                                                   changeNumber: processedChange.changeNumber) {

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -90,8 +90,10 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
             // MARK: Important. This should be called before loadLocal()
             // MARK: Part of /memberships hits optimization
             if self.storageContainer.generalInfoStorage.getSegmentsInUse() == nil {
+                Logger.v("Force Parsing DB")
                 splitsStorage.forceParsing()
                 ruleBasedSegmentsStorage.forceParsing()
+                TimeChecker.logInterval("Time for Force Parsing", startTime: start)
             }
             
             // Load local

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -90,7 +90,7 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
             // MARK: Important. This should be called before loadLocal()
             // MARK: Part of /memberships hits optimization
             if storageContainer.generalInfoStorage.getSegmentsInUse() == nil && storageContainer.splitsStorage.changeNumber > -1 {
-                Logger.v("Force Parsing DB")
+                Logger.v("Force Parsing flags")
                 splitsStorage.forceParsing()
                 ruleBasedSegmentsStorage.forceParsing()
                 TimeChecker.logInterval("Time for Force Parsing", startTime: start)

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -89,7 +89,7 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
             
             // MARK: Important. This should be called before loadLocal()
             // MARK: Part of /memberships hits optimization
-            if self.storageContainer.generalInfoStorage.getSegmentsInUse() == nil {
+            if storageContainer.generalInfoStorage.getSegmentsInUse() == nil && storageContainer.splitsStorage.getAll().count > 0 {
                 Logger.v("Force Parsing DB")
                 splitsStorage.forceParsing()
                 ruleBasedSegmentsStorage.forceParsing()

--- a/Split/Network/Sync/FeatureFlagsSynchronizer.swift
+++ b/Split/Network/Sync/FeatureFlagsSynchronizer.swift
@@ -89,7 +89,7 @@ class DefaultFeatureFlagsSynchronizer: FeatureFlagsSynchronizer {
             
             // MARK: Important. This should be called before loadLocal()
             // MARK: Part of /memberships hits optimization
-            if storageContainer.generalInfoStorage.getSegmentsInUse() == nil && storageContainer.splitsStorage.getAll().count > 0 {
+            if storageContainer.generalInfoStorage.getSegmentsInUse() == nil && storageContainer.splitsStorage.changeNumber > -1 {
                 Logger.v("Force Parsing DB")
                 splitsStorage.forceParsing()
                 ruleBasedSegmentsStorage.forceParsing()

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -97,7 +97,6 @@ class DefaultGeneralInfoStorage: GeneralInfoStorage {
     }
 
     func setSegmentsInUse(_ count: Int64) {
-        print(" ****       \(count)")
         segmentsInUse = count
         queue.async { [weak self] in
             self?.generalInfoDao.update(info: .segmentsInUse, longValue: count)

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -26,7 +26,7 @@ protocol GeneralInfoStorage {
 class DefaultGeneralInfoStorage: GeneralInfoStorage {
 
     private let generalInfoDao: GeneralInfoDao
-    private var queue = DispatchQueue(label: "io.split.DefaultGeneralInfoStorage")
+    private var queue = DispatchQueue(label: "io.split.DefaultGeneralInfoStorage", qos: .userInitiated)
     
     // Part of Smart Pausing Optimization Feature
     private var segmentsInUse: Int64? = nil

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -26,6 +26,10 @@ protocol GeneralInfoStorage {
 class DefaultGeneralInfoStorage: GeneralInfoStorage {
 
     private let generalInfoDao: GeneralInfoDao
+    private var queue = DispatchQueue(label: "io.split.DefaultGeneralInfoStorage")
+    
+    // Part of Smart Pausing Optimization Feature
+    private var segmentsInUse: Int64? = nil
 
     init(generalInfoDao: GeneralInfoDao) {
         self.generalInfoDao = generalInfoDao
@@ -84,10 +88,16 @@ class DefaultGeneralInfoStorage: GeneralInfoStorage {
     }
     
     func getSegmentsInUse() -> Int64? {
-        generalInfoDao.longValue(info: .segmentsInUse)
+        queue.async { [weak self] in
+            self?.segmentsInUse = self?.generalInfoDao.longValue(info: .segmentsInUse)
+        }
+        return segmentsInUse
     }
 
     func setSegmentsInUse(_ count: Int64) {
-        generalInfoDao.update(info: .segmentsInUse, longValue: count)
+        segmentsInUse = count
+        queue.async { [weak self] in
+            self?.generalInfoDao.update(info: .segmentsInUse, longValue: count)
+        }
     }
 }

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -88,13 +88,16 @@ class DefaultGeneralInfoStorage: GeneralInfoStorage {
     }
     
     func getSegmentsInUse() -> Int64? {
-        queue.async { [weak self] in
-            self?.segmentsInUse = self?.generalInfoDao.longValue(info: .segmentsInUse)
+        queue.sync {
+            if segmentsInUse == nil {
+                segmentsInUse = generalInfoDao.longValue(info: .segmentsInUse)
+            }
         }
         return segmentsInUse
     }
 
     func setSegmentsInUse(_ count: Int64) {
+        print(" ****       \(count)")
         segmentsInUse = count
         queue.async { [weak self] in
             self?.generalInfoDao.update(info: .segmentsInUse, longValue: count)

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -89,7 +89,7 @@ class DefaultGeneralInfoStorage: GeneralInfoStorage {
     
     func getSegmentsInUse() -> Int64? {
         queue.sync {
-            if segmentsInUse == nil {
+            if segmentsInUse == nil { // This happens just on start
                 segmentsInUse = generalInfoDao.longValue(info: .segmentsInUse)
             }
         }

--- a/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
+++ b/Split/Storage/GeneralInfo/GeneralInfoStorage.swift
@@ -26,7 +26,7 @@ protocol GeneralInfoStorage {
 class DefaultGeneralInfoStorage: GeneralInfoStorage {
 
     private let generalInfoDao: GeneralInfoDao
-    private var queue = DispatchQueue(label: "io.split.DefaultGeneralInfoStorage", qos: .userInitiated)
+    private var queue = DispatchQueue(label: "io.split.DefaultGeneralInfoStorage")
     
     // Part of Smart Pausing Optimization Feature
     private var segmentsInUse: Int64? = nil

--- a/Split/Storage/RuleBasedSegments/PersistentRuleBasedSegmentsStorage.swift
+++ b/Split/Storage/RuleBasedSegments/PersistentRuleBasedSegmentsStorage.swift
@@ -13,9 +13,6 @@ protocol PersistentRuleBasedSegmentsStorage {
     func update(toAdd: Set<RuleBasedSegment>, toRemove: Set<RuleBasedSegment>, changeNumber: Int64)
     func clear()
     func getChangeNumber() -> Int64
-    
-    func getSegmentsInUse() -> Int64?
-    func setSegmentsInUse(_ segmentsInUse: Int64)
 }
 
 class DefaultPersistentRuleBasedSegmentsStorage: PersistentRuleBasedSegmentsStorage {
@@ -57,13 +54,5 @@ class DefaultPersistentRuleBasedSegmentsStorage: PersistentRuleBasedSegmentsStor
 
     func getChangeNumber() -> Int64 {
         return generalInfoStorage.getRuleBasedSegmentsChangeNumber()
-    }
-    
-    func getSegmentsInUse() -> Int64? {
-        generalInfoStorage.getSegmentsInUse()
-    }
-    
-    func setSegmentsInUse(_ segmentsInUse: Int64) {
-        generalInfoStorage.setSegmentsInUse(segmentsInUse)
     }
 }

--- a/Split/Storage/RuleBasedSegments/RuleBasedSegmentsStorage.swift
+++ b/Split/Storage/RuleBasedSegments/RuleBasedSegmentsStorage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol RuleBasedSegmentsStorage: RolloutDefinitionsCache {
     var changeNumber: Int64 { get }
-    var segmentsInUse: Int64 { get }
+    var segmentsInUse: Int64 { get set }
 
     func get(segmentName: String) -> RuleBasedSegment?
     func contains(segmentNames: Set<String>) -> Bool
@@ -26,7 +26,7 @@ class DefaultRuleBasedSegmentsStorage: RuleBasedSegmentsStorage {
 
     private(set) var changeNumber: Int64 = -1
     
-    internal var segmentsInUse: Int64 = 0
+    var segmentsInUse: Int64 = 0
 
     init(persistentStorage: PersistentRuleBasedSegmentsStorage) {
         self.persistentStorage = persistentStorage
@@ -68,7 +68,6 @@ class DefaultRuleBasedSegmentsStorage: RuleBasedSegmentsStorage {
 
     func update(toAdd: Set<RuleBasedSegment>, toRemove: Set<RuleBasedSegment>, changeNumber: Int64) -> Bool {
         
-        segmentsInUse = persistentStorage.getSegmentsInUse() ?? 0
         self.changeNumber = changeNumber
         
         // Process

--- a/Split/Storage/RuleBasedSegments/RuleBasedSegmentsStorage.swift
+++ b/Split/Storage/RuleBasedSegments/RuleBasedSegmentsStorage.swift
@@ -68,6 +68,7 @@ class DefaultRuleBasedSegmentsStorage: RuleBasedSegmentsStorage {
 
     func update(toAdd: Set<RuleBasedSegment>, toRemove: Set<RuleBasedSegment>, changeNumber: Int64) -> Bool {
         
+        segmentsInUse = persistentStorage.getSegmentsInUse() ?? 0
         self.changeNumber = changeNumber
         
         // Process

--- a/Split/Storage/Splits/PersistentSplitsStorage.swift
+++ b/Split/Storage/Splits/PersistentSplitsStorage.swift
@@ -12,12 +12,10 @@ protocol PersistentSplitsStorage {
     func update(splitChange: ProcessedSplitChange)
     func update(split: Split)
     func update(bySetsFilter: SplitFilter?)
-    func update(segmentsInUse: Int64)
     func getBySetsFilter() -> SplitFilter?
     func getSplitsSnapshot() -> SplitsSnapshot
     func getChangeNumber() -> Int64
     func getUpdateTimestamp() -> Int64
-    func getSegmentsInUse() -> Int64?
     func getAll() -> [Split]
     func delete(splitNames: [String])
     func clear()
@@ -51,10 +49,6 @@ class DefaultPersistentSplitsStorage: PersistentSplitsStorage {
     func update(flagsSpec: String) {
         generalInfoDao.update(info: .flagsSpec, stringValue: flagsSpec)
     }
-    
-    func update(segmentsInUse: Int64) {
-        generalInfoDao.update(info: .segmentsInUse, longValue: segmentsInUse)
-    }
 
     func getFilterQueryString() -> String {
         return generalInfoDao.stringValue(info: .splitsFilterQueryString) ?? ""
@@ -62,10 +56,6 @@ class DefaultPersistentSplitsStorage: PersistentSplitsStorage {
 
     func getFlagsSpec() -> String {
         return generalInfoDao.stringValue(info: .flagsSpec) ?? ""
-    }
-    
-    func getSegmentsInUse() -> Int64? {
-        generalInfoDao.longValue(info: .segmentsInUse)
     }
 
     func update(bySetsFilter filter: SplitFilter?) {

--- a/Split/Storage/Splits/SplitsStorage.swift
+++ b/Split/Storage/Splits/SplitsStorage.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol SyncSplitsStorage: RolloutDefinitionsCache {
     func update(splitChange: ProcessedSplitChange) -> Bool
+    func getSegmentsInUse() -> Int64
 }
 
 protocol SplitsStorage: SyncSplitsStorage {
@@ -28,6 +29,7 @@ protocol SplitsStorage: SyncSplitsStorage {
     func getCount() -> Int
     func destroy()
     func forceParsing()
+    func getSegmentsInUse() -> Int64
 }
 
 class DefaultSplitsStorage: SplitsStorage {
@@ -36,7 +38,7 @@ class DefaultSplitsStorage: SplitsStorage {
     private var inMemorySplits: SynchronizedDictionary<String, Split>
     private var trafficTypes: SynchronizedDictionary<String, Int>
     private let flagSetsCache: FlagSetsCache
-    internal var segmentsInUse: Int64 = 0
+    var segmentsInUse: Int64 = 0
     
     private(set) var changeNumber: Int64 = -1
     private(set) var updateTimestamp: Int64 = -1
@@ -119,6 +121,10 @@ class DefaultSplitsStorage: SplitsStorage {
 
     func getCount() -> Int {
         return inMemorySplits.count
+    }
+    
+    func getSegmentsInUse() -> Int64 {
+        segmentsInUse
     }
     
     private func processUpdated(splits: [Split], active: Bool) -> Bool {
@@ -276,6 +282,10 @@ class BackgroundSyncSplitsStorage: SyncSplitsStorage {
 
     func clear() {
         persistentStorage.clear()
+    }
+    
+    func getSegmentsInUse() -> Int64 {
+        persistentStorage.getSegmentsInUse() ?? 0
     }
 }
 

--- a/SplitTests/Fake/Storage/GeneralInfoStorageMock.swift
+++ b/SplitTests/Fake/Storage/GeneralInfoStorageMock.swift
@@ -10,7 +10,7 @@ class GeneralInfoStorageMock: GeneralInfoStorage {
     var flagsSpec = ""
     var ruleBasedSegmentsChangeNumber: Int64 = -1
     var lastProxyUpdateTimestamp: Int64 = 0
-    var segmentsInUse: Int64 = 0
+    var segmentsInUse: Int64? = nil
 
     func getUpdateTimestamp() -> Int64 {
         return updateTimestamp

--- a/SplitTests/Fake/Storage/PersistentRuleBasedSegmentsStorageStub.swift
+++ b/SplitTests/Fake/Storage/PersistentRuleBasedSegmentsStorageStub.swift
@@ -59,13 +59,4 @@ class PersistentRuleBasedSegmentsStorageStub: PersistentRuleBasedSegmentsStorage
         changeNumberCalled = true
         return delegate?.getChangeNumber() ?? -1
     }
-    
-    var segmentsInUse: Int64 = 0
-    func getSegmentsInUse() -> Int64? {
-        segmentsInUse
-    }
-    
-    func setSegmentsInUse(_ segmentsInUse: Int64) {
-        self.segmentsInUse = segmentsInUse
-    }
 }

--- a/SplitTests/Fake/Storage/PersistentSplitsStorageStub.swift
+++ b/SplitTests/Fake/Storage/PersistentSplitsStorageStub.swift
@@ -21,7 +21,6 @@ class PersistentSplitsStorageStub: PersistentSplitsStorage {
 
     var getAllCalled = false
     var updateCalled = false
-    var getSegmentsInUseCalled = false
     var deleteCalled = false
     var clearCalled = false
     var closeCalled = false
@@ -97,16 +96,5 @@ class PersistentSplitsStorageStub: PersistentSplitsStorage {
     func getBySetsFilter() -> SplitFilter? {
         getBySetsFilterCalled = false
         return nil
-    }
-    
-    var segmentsInUse: Int64 = 0
-    func update(segmentsInUse: Int64) {
-        self.segmentsInUse = segmentsInUse
-        delegate?.update(segmentsInUse: segmentsInUse)
-    }
-    
-    func getSegmentsInUse() -> Int64? {
-        getSegmentsInUseCalled = true
-        return segmentsInUse
     }
 }

--- a/SplitTests/Fake/Storage/SplitsStorageStub.swift
+++ b/SplitTests/Fake/Storage/SplitsStorageStub.swift
@@ -73,6 +73,10 @@ class SplitsStorageStub: SplitsStorage {
         updateSplitChangeCalled = true
         return splitsWereUpdated
     }
+    
+    func getSegmentsInUse() -> Int64 {
+        segmentsInUse
+    }
 
     var updateFlagsSpecCalled = false
     func update(flagsSpec: String) {

--- a/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
+++ b/SplitTests/Integration/Sync/SplitSdkUpdatePollingTest.swift
@@ -60,24 +60,12 @@ class SplitSdkUpdatePollingTest: XCTestCase {
                 } else if index == self.spExp.count {
                     self.spExp[index - 1].fulfill()
                 }
-                let json = IntegrationHelper.loadSplitChangeFileJson(name: "splitschanges_no_segments", sourceClass: IntegrationHelper())
+                let json = IntegrationHelper.loadSplitChangeFileJson(name: "splitchanges_1", sourceClass: IntegrationHelper())
                 return TestDispatcherResponse(code: 200, data: Data(json!.utf8))
             }
 
             if request.isMySegmentsEndpoint() {
-                self.mySegmentsHits+=1
-                let hit = self.mySegmentsHits
-                var json = IntegrationHelper.emptyMySegments
-                if hit > 2 {
-                    var mySegments = [String]()
-                    for i in 1...hit {
-                        mySegments.append("segment\(i)")
-                    }
-
-                    json = IntegrationHelper.buildSegments(regular: mySegments)
-                    return TestDispatcherResponse(code: 200, data: Data(json.utf8))
-                }
-                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.mySegments(names: ["", ""]).utf8))
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
             }
 
             if request.isAuthEndpoint() {
@@ -166,7 +154,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
         let sdkUpdate = XCTestExpectation(description: "SDK Update Expectation")
 
         let splitConfig: SplitClientConfig = SplitClientConfig()
-        splitConfig.segmentsRefreshRate = 99999
+        splitConfig.segmentsRefreshRate = 2
         splitConfig.featuresRefreshRate = 2
         splitConfig.impressionRefreshRate = 99999
         splitConfig.sdkReadyTimeOut = 60000
@@ -183,24 +171,15 @@ class SplitSdkUpdatePollingTest: XCTestCase {
 
         let client = factory!.client
 
-        var sdkReadyFired = false
-        var sdkUpdatedFired = false
-
         client.on(event: SplitEvent.sdkReady) {
-            sdkReadyFired = true
             sdkReady.fulfill()
         }
 
         client.on(event: SplitEvent.sdkUpdated) {
-            sdkUpdatedFired = true
             sdkUpdate.fulfill()
         }
 
         wait(for: [sdkReady, sdkUpdate], timeout: 30)
-
-        XCTAssertTrue(sdkReadyFired)
-        XCTAssertTrue(sdkUpdatedFired)
-
 
         let semaphore = DispatchSemaphore(value: 0)
         client.destroy(completion: {
@@ -218,7 +197,7 @@ class SplitSdkUpdatePollingTest: XCTestCase {
 
         let splitConfig: SplitClientConfig = SplitClientConfig()
         splitConfig.segmentsRefreshRate = 2
-        splitConfig.featuresRefreshRate = 999999
+        splitConfig.featuresRefreshRate = 2
         splitConfig.impressionRefreshRate = 999999
         splitConfig.sdkReadyTimeOut = 60000
         splitConfig.trafficType = trafficType

--- a/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
+++ b/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
@@ -1,4 +1,3 @@
-//
 //  MySegmentUpdateTest.swift
 //  SplitTests
 //
@@ -450,9 +449,9 @@ class MySegmentUpdateTest: XCTestCase {
     func testSdkRestartMembershipsSyncIfNewFlag() throws {
         
         var sdkReadyFired = false
-        var cacheReadyFired = true
         let sdkReady = XCTestExpectation(description: "SDK should be ready")
         let cacheReadyExp = XCTestExpectation(description: "Cache should be ready")
+        let sdkUpdateExp = XCTestExpectation(description: "SDK Should fire updated")
         let segmentsHit = XCTestExpectation(description: "/memberships should be hit at least once")
         var membershipsHit = 0
         
@@ -510,7 +509,10 @@ class MySegmentUpdateTest: XCTestCase {
         
         client?.on(event: .sdkReadyFromCache) {
             cacheReadyExp.fulfill()
-            cacheReadyFired = true
+        }
+        
+        client?.on(event: .sdkUpdated) {
+            sdkUpdateExp.fulfill()
         }
         
         wait(for: [segmentsHit], timeout: 3)
@@ -529,7 +531,7 @@ class MySegmentUpdateTest: XCTestCase {
         
         waitExp = XCTestExpectation(description: "Just waiting")
         waitExp.isInverted = true // Inverted expectation
-        wait(for: [waitExp], timeout: 5)
+        wait(for: [waitExp, sdkUpdateExp], timeout: 5)
         XCTAssertGreaterThan(membershipsHit, 2, "If new flags with segments arrive, the mechanism should be restarted and SDK should hit /memberships many times again")
         
         // Cleanup

--- a/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
+++ b/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
@@ -693,7 +693,6 @@ class MySegmentUpdateTest: XCTestCase {
 
         wait(for: [sdkUpdExp, sdkUpdMExp], timeout: 15)
 
-
         // Hits are not asserted because tests will fail if expectations are not fulfilled
         XCTAssertEqual(4, syncSpy.forceMySegmentsSyncCount[userKey] ?? 0)
         XCTAssertEqual(4, syncSpy.forceMySegmentsSyncCount[userKeyM] ?? 0)

--- a/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
+++ b/SplitTests/Integration/streaming/MySegmentUpdateTest.swift
@@ -467,6 +467,7 @@ class MySegmentUpdateTest: XCTestCase {
             if request.url.absoluteString.contains("/memberships") {
                 segmentsHit.fulfill()
                 membershipsHit += 1
+                print("HITTING MEMBERSHIPS")
                 return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
             }
             

--- a/SplitTests/Integration/streaming/TelemetryIntegrationTest.swift
+++ b/SplitTests/Integration/streaming/TelemetryIntegrationTest.swift
@@ -112,7 +112,6 @@ class TelemetryIntegrationTest: XCTestCase {
         splitConfig.telemetryRefreshRate = 99999
         splitConfig.impressionRefreshRate = 99999
         splitConfig.eventsPushRate = 99999
-        //splitConfig.isDebugModeEnabled = true
 
         let key: Key = Key(matchingKey: userKey)
         let builder = DefaultSplitFactoryBuilder()
@@ -127,11 +126,11 @@ class TelemetryIntegrationTest: XCTestCase {
 
         let sdkReadyExpectation = XCTestExpectation(description: "SDK READY Expectation")
 
-        client.on(event: SplitEvent.sdkReady) {
+        client.on(event: .sdkReady) {
             sdkReadyExpectation.fulfill()
         }
 
-        client.on(event: SplitEvent.sdkReadyTimedOut) {
+        client.on(event: .sdkReadyTimedOut) {
             IntegrationHelper.tlog("TIMEOUT")
         }
 

--- a/SplitTests/Service/Splits/SplitsBgSyncWorkerTest.swift
+++ b/SplitTests/Service/Splits/SplitsBgSyncWorkerTest.swift
@@ -19,6 +19,7 @@ class SplitsBgSyncWorkerTest: XCTestCase {
     var splitChangeProcessor: SplitChangeProcessorStub!
     var ruleBasedSegmentChangeProcessor: RuleBasedSegmentChangeProcessorStub!
     var splitsSyncWorker: BackgroundSyncWorker!
+    var generalInfoStorage: GeneralInfoStorageMock!
 
     override func setUp() {
         splitFetcher = HttpSplitFetcherStub()
@@ -38,7 +39,8 @@ class SplitsBgSyncWorkerTest: XCTestCase {
                                                       splitChangeProcessor: splitChangeProcessor,
                                                       ruleBasedSegmentsChangeProcessor: ruleBasedSegmentChangeProcessor,
                                                       cacheExpiration: 100,
-                                                      splitConfig: SplitClientConfig())
+                                                      splitConfig: SplitClientConfig(),
+                                                      generalInfoStorage: generalInfoStorage)
 
         let change = SplitChange(splits: [], since: 200, till: 200)
         splitFetcher.splitChanges = [TargetingRulesChange(featureFlags: change)]
@@ -57,7 +59,8 @@ class SplitsBgSyncWorkerTest: XCTestCase {
                                                       splitChangeProcessor: splitChangeProcessor,
                                                       ruleBasedSegmentsChangeProcessor: ruleBasedSegmentChangeProcessor,
                                                       cacheExpiration: 100,
-                                                      splitConfig: SplitClientConfig())
+                                                      splitConfig: SplitClientConfig(),
+                                                      generalInfoStorage: generalInfoStorage)
 
         splitFetcher.httpError = HttpError.clientRelated(code: -1, internalCode: -1)
 
@@ -76,8 +79,9 @@ class SplitsBgSyncWorkerTest: XCTestCase {
                                                       splitChangeProcessor: splitChangeProcessor,
                                                       ruleBasedSegmentsChangeProcessor: ruleBasedSegmentChangeProcessor,
                                                       cacheExpiration: 2000,
-                                                      splitConfig: SplitClientConfig())
-
+                                                      splitConfig: SplitClientConfig(),
+                                                      generalInfoStorage: generalInfoStorage)
+        
         let change = SplitChange(splits: [], since: 200, till: 200)
         splitStorage.updateTimestamp = Int64(Date().timeIntervalSince1970) - Int64(expiration / 2) // Non Expired cache
         splitFetcher.splitChanges = [TargetingRulesChange(featureFlags: change)]

--- a/SplitTests/Service/Splits/SplitsBgSyncWorkerTest.swift
+++ b/SplitTests/Service/Splits/SplitsBgSyncWorkerTest.swift
@@ -19,7 +19,7 @@ class SplitsBgSyncWorkerTest: XCTestCase {
     var splitChangeProcessor: SplitChangeProcessorStub!
     var ruleBasedSegmentChangeProcessor: RuleBasedSegmentChangeProcessorStub!
     var splitsSyncWorker: BackgroundSyncWorker!
-    var generalInfoStorage: GeneralInfoStorageMock!
+    var generalInfoStorage = GeneralInfoStorageMock()
 
     override func setUp() {
         splitFetcher = HttpSplitFetcherStub()

--- a/SplitTests/Storage/RuleBasedSegmentStorageTest.swift
+++ b/SplitTests/Storage/RuleBasedSegmentStorageTest.swift
@@ -15,7 +15,7 @@ class RuleBasedSegmentStorageTest: XCTestCase {
     private var persistentStorageStub: PersistentRuleBasedSegmentsStorageStub!
     private var ruleBasedSegmentsStorage: DefaultRuleBasedSegmentsStorage!
     private var noLoadedRbs: DefaultRuleBasedSegmentsStorage?
-    private var generalInfoStorage: GeneralInfoStorageMock!
+    private var generalInfoStorage = GeneralInfoStorageMock()
 
     override func setUp() {
         ruleBasedSegmentsStorage = DefaultRuleBasedSegmentsStorage(persistentStorage: createPersistentStorageStub(), generalInfoStorage: generalInfoStorage)

--- a/SplitTests/Storage/RuleBasedSegmentStorageTest.swift
+++ b/SplitTests/Storage/RuleBasedSegmentStorageTest.swift
@@ -15,11 +15,10 @@ class RuleBasedSegmentStorageTest: XCTestCase {
     private var persistentStorageStub: PersistentRuleBasedSegmentsStorageStub!
     private var ruleBasedSegmentsStorage: DefaultRuleBasedSegmentsStorage!
     private var noLoadedRbs: DefaultRuleBasedSegmentsStorage?
+    private var generalInfoStorage: GeneralInfoStorageMock!
 
     override func setUp() {
-        ruleBasedSegmentsStorage = DefaultRuleBasedSegmentsStorage(
-            persistentStorage: createPersistentStorageStub()
-        )
+        ruleBasedSegmentsStorage = DefaultRuleBasedSegmentsStorage(persistentStorage: createPersistentStorageStub(), generalInfoStorage: generalInfoStorage)
         ruleBasedSegmentsStorage.loadLocal()
     }
 
@@ -30,9 +29,7 @@ class RuleBasedSegmentStorageTest: XCTestCase {
     }
     
     func testLazyParsing() {
-        noLoadedRbs = DefaultRuleBasedSegmentsStorage(
-            persistentStorage: createPersistentStorageStub(isParsed: false)
-        )
+        noLoadedRbs = DefaultRuleBasedSegmentsStorage(persistentStorage: createPersistentStorageStub(isParsed: false), generalInfoStorage: generalInfoStorage)
         
         noLoadedRbs?.loadLocal()
 
@@ -71,7 +68,7 @@ class RuleBasedSegmentStorageTest: XCTestCase {
         let customMock = MockPersistentRuleBasedSegmentsStorage()
         let persistentStorageStub = PersistentRuleBasedSegmentsStorageStub(delegate: customMock)
         let storage = DefaultRuleBasedSegmentsStorage(
-            persistentStorage: persistentStorageStub
+            persistentStorage: persistentStorageStub, generalInfoStorage: generalInfoStorage
         )
         storage.loadLocal()
 
@@ -110,9 +107,8 @@ class RuleBasedSegmentStorageTest: XCTestCase {
         )
 
         persistentStorageStub = PersistentRuleBasedSegmentsStorageStub(delegate: customMock)
-        let storage = DefaultRuleBasedSegmentsStorage(
-            persistentStorage: persistentStorageStub
-        )
+        let storage = DefaultRuleBasedSegmentsStorage(persistentStorage: persistentStorageStub, generalInfoStorage: generalInfoStorage)
+        
         storage.loadLocal()
 
         // Verify only active segments are loaded
@@ -303,7 +299,7 @@ class RuleBasedSegmentStorageTest: XCTestCase {
 
         // 1. Counter should be 3 (ignore the other matcherTypes)
         _ = ruleBasedSegmentsStorage.update(toAdd: Set([segment1, segment2, segment3, segment4, segment5]), toRemove: [], changeNumber: 123)
-        XCTAssertEqual(ruleBasedSegmentsStorage.segmentsInUse, 3)
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 3)
         
         // 2
         segment1.status = .archived // Archive of Segments with other matcherTypes should be ignored..
@@ -311,7 +307,7 @@ class RuleBasedSegmentStorageTest: XCTestCase {
         segment3.status = .archived
         _ = ruleBasedSegmentsStorage.update(toAdd: Set([]), toRemove: [segment1, segment2, segment3], changeNumber: 1230)
         
-        XCTAssertEqual(ruleBasedSegmentsStorage.segmentsInUse, 1)
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 1)
     }
 
 

--- a/SplitTests/Storage/SplitsStorageTests.swift
+++ b/SplitTests/Storage/SplitsStorageTests.swift
@@ -20,7 +20,7 @@ class SplitsStorageTest: XCTestCase {
     var persistentStorage: PersistentSplitsStorageStub!
     var splitsStorage: SplitsStorage!
     var noLoadedStorage: DefaultSplitsStorage?
-    var generalInfoStorage: GeneralInfoStorageMock!
+    var generalInfoStorage = GeneralInfoStorageMock()
 
     override func setUp() {
         persistentStorage = PersistentSplitsStorageStub()

--- a/SplitTests/Storage/SplitsStorageTests.swift
+++ b/SplitTests/Storage/SplitsStorageTests.swift
@@ -20,11 +20,12 @@ class SplitsStorageTest: XCTestCase {
     var persistentStorage: PersistentSplitsStorageStub!
     var splitsStorage: SplitsStorage!
     var noLoadedStorage: DefaultSplitsStorage?
+    var generalInfoStorage: GeneralInfoStorageMock!
 
     override func setUp() {
         persistentStorage = PersistentSplitsStorageStub()
         flagSetsCache = FlagSetsCacheMock()
-        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistentStorage, flagSetsCache: flagSetsCache)
+        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistentStorage, flagSetsCache: flagSetsCache, GeneralInfoStorage: generalInfoStorage)
     }
 
     func testNoLocalLoaded() {
@@ -39,9 +40,7 @@ class SplitsStorageTest: XCTestCase {
     }
     
     func testLazyParsing() {
-        noLoadedStorage = DefaultSplitsStorage(
-            persistentSplitsStorage: createPersistentStorageStub(isParsed: false), flagSetsCache: FlagSetsCacheMock()
-        )
+        noLoadedStorage = DefaultSplitsStorage(persistentSplitsStorage: createPersistentStorageStub(isParsed: false), flagSetsCache: FlagSetsCacheMock(), GeneralInfoStorage: generalInfoStorage)
         
         noLoadedStorage?.loadLocal()
 
@@ -279,14 +278,12 @@ class SplitsStorageTest: XCTestCase {
 
         let flagSetsCache = FlagSetsCacheMock()
         flagSetsCache.setsInFilter = ["set1", "set2", "set3"]
-        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistentStorage, flagSetsCache: flagSetsCache)
-        persistentStorage.snapshot = getTestSnapshot(count: 3,
-                                                     sets: [
-                                                        ["set1", "set2"],
-                                                        ["set1"],
-                                                        ["set3"]
-                                                     ]
-        )
+        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistentStorage, flagSetsCache: flagSetsCache, GeneralInfoStorage: GeneralInfoStorageMock())
+        persistentStorage.snapshot = getTestSnapshot(count: 3, sets: [
+                                                                       ["set1", "set2"],
+                                                                       ["set1"],
+                                                                       ["set3"]
+                                                                     ])
 
         splitsStorage.loadLocal()
 
@@ -326,7 +323,7 @@ class SplitsStorageTest: XCTestCase {
         splitsStorage.loadLocal()
 
         // 1. Check Segments count is in 0
-        XCTAssertEqual(splitsStorage.segmentsInUse, 0)
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 0)
         
         let splitNotUsingSegments = newSplit(name: "added")
         
@@ -336,9 +333,8 @@ class SplitsStorageTest: XCTestCase {
                                                    changeNumber: 999, updateTimestamp: 888)
 
         _ = splitsStorage.update(splitChange: processedChange)
-        XCTAssertEqual(splitsStorage.segmentsInUse, 5) // One should have been ignored, so 5
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 5) // One should have been ignored, so 5
         XCTAssertTrue(persistentStorage.updateCalled)
-        XCTAssertTrue(persistentStorage.getSegmentsInUseCalled)
         
         // 3. Add 2 previously added (should be ignored by the counter), and a new one
         processedChange = ProcessedSplitChange(activeSplits: [split, split2, split6],
@@ -346,7 +342,7 @@ class SplitsStorageTest: XCTestCase {
                                                changeNumber: 9999, updateTimestamp: 8888)
         
         _ = splitsStorage.update(splitChange: processedChange)
-        XCTAssertEqual(splitsStorage.segmentsInUse, 6) // So, count should be 6
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 6) // So, count should be 6
         
         // 4. Remove 3 (one not using segments)
         split2.status = .archived
@@ -357,7 +353,7 @@ class SplitsStorageTest: XCTestCase {
                                                changeNumber: 99999, updateTimestamp: 88888)
         
         _ = splitsStorage.update(splitChange: processedChange)
-        XCTAssertEqual(splitsStorage.segmentsInUse, 4) // So, count should be 4
+        XCTAssertEqual(generalInfoStorage.getSegmentsInUse(), 4) // So, count should be 4
     }
 
     func testUnsupportedMatcherHasDefaultCondition() {

--- a/SplitTests/Storage/SplitsStorageTrafficTypesTests.swift
+++ b/SplitTests/Storage/SplitsStorageTrafficTypesTests.swift
@@ -14,6 +14,7 @@ class SplitsStorageTrafficTypesTests: XCTestCase {
     
     var splitsStorage: SplitsStorage!
     var flagSetsCache: FlagSetsCacheMock!
+    var generalInfoStorage: GeneralInfoStorageMock!
 
     override func setUp() {
         
@@ -26,7 +27,7 @@ class SplitsStorageTrafficTypesTests: XCTestCase {
         flagSetsCache = FlagSetsCacheMock()
 
         persistent.snapshot = SplitsSnapshot(changeNumber: 1, splits: splits, updateTimestamp: 100)
-        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistent, flagSetsCache: flagSetsCache)
+        splitsStorage = DefaultSplitsStorage(persistentSplitsStorage: persistent, flagSetsCache: flagSetsCache, GeneralInfoStorage: generalInfoStorage)
         splitsStorage.loadLocal()
     }
 

--- a/SplitTests/Storage/SplitsStorageTrafficTypesTests.swift
+++ b/SplitTests/Storage/SplitsStorageTrafficTypesTests.swift
@@ -14,7 +14,7 @@ class SplitsStorageTrafficTypesTests: XCTestCase {
     
     var splitsStorage: SplitsStorage!
     var flagSetsCache: FlagSetsCacheMock!
-    var generalInfoStorage: GeneralInfoStorageMock!
+    var generalInfoStorage = GeneralInfoStorageMock()
 
     override func setUp() {
         


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?

- Bypass CoreData between Storages, to improve SDK_READY times
- Fixed old test that were not running
- Refactor of Storages and GeneralInfoStorage
- Centralized count of SegmentsInUse

<img width="740" height="27" alt="image" src="https://github.com/user-attachments/assets/1d046dbe-93e3-4410-9613-e9e2d02e881b" />


## How do we test the changes introduced in this PR?

## Extra Notes