### PR TITLE
Release/3.7.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.7.1: (Feb 19, 2026)
+- Improved impressions persistence and submission.
+
 3.7.0: (Jan 28, 2026)
 - Added functionality to provide metadata alongside SDK update and READY events. Read more in our docs.
 

--- a/Split.podspec
+++ b/Split.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
   s.module_name      = 'Split'
-  s.version          = '3.7.0'
+  s.version          = '3.7.1-rc2'
   s.summary          = 'iOS SDK for Split'
   s.description      = <<-DESC
 This SDK is designed to work with Split, the platform for controlled rollouts, serving features to your users via the Split feature flag to manage your complete customer experience.

--- a/Split.podspec
+++ b/Split.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Split'
   s.module_name      = 'Split'
-  s.version          = '3.7.1-rc2'
+  s.version          = '3.7.1'
   s.summary          = 'iOS SDK for Split'
   s.description      = <<-DESC
 This SDK is designed to work with Split, the platform for controlled rollouts, serving features to your users via the Split feature flag to manage your complete customer experience.

--- a/Split/Common/Utils/Version.swift
+++ b/Split/Common/Utils/Version.swift
@@ -10,7 +10,7 @@ import Foundation
 class Version {
     private static let kSdkPlatform: String = "ios"
 
-    private static let kVersion = "3.7.0"
+    private static let kVersion = "3.7.1-rc2"
 
     static var semantic: String {
         return kVersion

--- a/Split/Common/Utils/Version.swift
+++ b/Split/Common/Utils/Version.swift
@@ -10,7 +10,7 @@ import Foundation
 class Version {
     private static let kSdkPlatform: String = "ios"
 
-    private static let kVersion = "3.7.1-rc2"
+    private static let kVersion = "3.7.1"
 
     static var semantic: String {
         return kVersion

--- a/Split/FetcherEngine/Recorder/ImpressionsRecorderWorker.swift
+++ b/Split/FetcherEngine/Recorder/ImpressionsRecorderWorker.swift
@@ -29,7 +29,7 @@ class ImpressionsRecorderWorker: RecorderWorker, @unchecked Sendable {
 
     func flush() {
         var rowCount = 0
-        var failedImpressions = [KeyImpression]()
+        var failedCount = 0
         repeat {
             let impressions = persistentImpressionsStorage.pop(count: impressionsPerPush)
             rowCount = impressions.count
@@ -42,18 +42,17 @@ class ImpressionsRecorderWorker: RecorderWorker, @unchecked Sendable {
                     Logger.i("Impressions posted successfully")
                 } catch let error {
                     Logger.e("Impression error: \(String(describing: error))")
-                    failedImpressions.append(contentsOf: impressions)
+                    // Impressions remain in DB for retry on next flush cycle
+                    failedCount = rowCount
+                    break
                 }
             }
         } while rowCount == impressionsPerPush
-        // Activate non sent impressions to retry in next iteration
-        persistentImpressionsStorage.setActive(failedImpressions)
         if let syncHelper = impressionsSyncHelper {
-            syncHelper.updateAccumulator(count: failedImpressions.count,
-                                         bytes: failedImpressions.count *
+            syncHelper.updateAccumulator(count: failedCount,
+                                         bytes: failedCount *
                                             ServiceConstants.estimatedImpressionSizeInBytes)
         }
-
     }
 
     private func group(impressions: [KeyImpression]) -> [ImpressionsTest] {

--- a/Split/Storage/Impressions/ImpressionDao.swift
+++ b/Split/Storage/Impressions/ImpressionDao.swift
@@ -51,7 +51,7 @@ class CoreDataImpressionDao: BaseCoreDataDao, ImpressionDao, @unchecked Sendable
                 return
             }
 
-            let predicate = NSPredicate(format: "createdAt >= %d AND status == %d", createdAt, status)
+            let predicate = NSPredicate(format: "createdAt >= %d", createdAt)
             let entities = self.coreDataHelper.fetch(entity: .impression,
                                                 where: predicate,
                                                 rowLimit: maxRows).compactMap { return $0 as? ImpressionEntity }

--- a/Split/Storage/Impressions/ImpressionEntity.swift
+++ b/Split/Storage/Impressions/ImpressionEntity.swift
@@ -15,6 +15,7 @@ class ImpressionEntity: NSManagedObject {
     @NSManaged public var storageId: String
     @NSManaged public var body: String
     @NSManaged public var createdAt: Int64
+    // status is not queried anymore, but we keep it for backward compatibility
     @NSManaged public var status: Int32
     @NSManaged public var testName: String
 }

--- a/Split/Storage/Impressions/PersistentImpressionsStorage.swift
+++ b/Split/Storage/Impressions/PersistentImpressionsStorage.swift
@@ -30,7 +30,6 @@ class DefaultImpressionsStorage: PersistentImpressionsStorage, @unchecked Sendab
     func pop(count: Int) -> [KeyImpression] {
         let createdAt = Date().unixTimestamp() - self.expirationPeriod
         let impressions = impressionDao.getBy(createdAt: createdAt, status: StorageRecordStatus.active, maxRows: count)
-        impressionDao.update(ids: impressions.compactMap { $0.storageId }, newStatus: StorageRecordStatus.deleted)
         return impressions
     }
 

--- a/SplitTests/Fake/Storage/PersistentImpressionsStorageStub.swift
+++ b/SplitTests/Fake/Storage/PersistentImpressionsStorageStub.swift
@@ -26,12 +26,7 @@ class PersistentImpressionsStorageStub: PersistentImpressionsStorage, @unchecked
     }
 
     func pop(count: Int) -> [KeyImpression] {
-        let deleted = impressionsStatus.filter { $0.value == StorageRecordStatus.deleted }.keys
-        let poped = Array(storedImpressions.values.filter { !deleted.contains($0.storageId ?? "") }.prefix(count))
-        for impression in poped {
-            impressionsStatus[impression.storageId ?? ""] = StorageRecordStatus.deleted
-        }
-        return poped
+        return Array(storedImpressions.values.prefix(count))
     }
 
     func push(impression: KeyImpression) {

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -945,4 +945,148 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
     private func queryImpressionCount() -> Int {
         return db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.active, maxRows: 1_000_000).count
     }
+
+    // MARK: - Two-Coordinator Collision Test
+
+        /**
+         Scenario: back-to-back factory creation on the same SQLite file — no impression loss
+         despite concurrent insert/delete across uncoordinated NSPersistentStoreCoordinators.
+
+         Replicates the reported customer scenario:
+         - Client A (factory A) does many getTreatment evaluations with impression properties.
+           Each evaluation inserts one impression with an individual save() — no deduplication
+           because properties make each impression unique.
+         - Client A calls flush().
+         - Client B (factory B, same SDK key + same DB prefix) is created "back to back".
+           Each factory creates its own NSPersistentStoreCoordinator, both pointing at the
+           same SQLite file.
+         - Client B's periodic timer fires immediately (deadline: 0) — it pops committed
+           impressions from SQLite, posts them, and deletes them.
+         - The collision: Client A's ongoing insert save() and Client B's delete save()
+           compete for the SQLite write lock. With no busy-timeout configured,
+           the loser gets SQLITE_BUSY and CoreDataHelper.save() swallows the error.
+
+         The test verifies that despite this contention, all impressions are accounted for:
+         either posted to the server or still recoverable in the database.
+         */
+    func testBackToBackFactoriesOnSameDbFileNoImpressionLoss() {
+        let databaseName = "impressions_two_coordinators_e2e"
+        removeDatabaseFiles(databaseName: databaseName)
+
+        let postQueue = DispatchQueue(label: "two-coord-post-queue")
+        var clientAPostCount = 0
+        var clientBPostCount = 0
+
+        let evaluationCountA = 200
+        let evaluationCountB = 50
+
+        // Client A dispatcher: count posted impressions
+        let dispatcherA = buildOrphanTestDispatcher { request in
+            postQueue.sync {
+                clientAPostCount += self.parseImpressionCount(from: request)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        // Client B dispatcher: count posted impressions
+        let dispatcherB = buildOrphanTestDispatcher { request in
+            postQueue.sync {
+                clientBPostCount += self.parseImpressionCount(from: request)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        // --- Client A: first NSPersistentStoreCoordinator on file-backed DB ---
+        guard let helperA = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create DB helper for Client A")
+            return
+        }
+        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperA)
+        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcherA)
+        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey) { config in
+            config.impressionsQueueSize = 100_000
+            config.impressionsChunkSize = 100_000
+        }
+
+        // Client A generates many impressions. Each getTreatment triggers an async
+        // insert (context.perform { create + save() }). The saves are queued on
+        // Context A's serial queue and will still be executing after this returns.
+        generateImpressions(client: clientA, count: evaluationCountA)
+
+        // Client A calls flush() — async (DispatchQueue.general → flushQueue).
+        // Inserts may still be in progress on Context A's queue.
+        clientA.flush()
+
+        // --- Client B: SECOND NSPersistentStoreCoordinator on SAME SQLite file ---
+        // Created "back to back" while Client A is still inserting.
+        // Client B's periodic timer fires immediately (deadline: 0). Its pop() reads
+        // from SQLite; its post + delete save() may collide with Client A's ongoing
+        // insert save() at the SQLite write lock (SQLITE_BUSY, no busy-wait).
+        guard let helperB = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create DB helper for Client B")
+            return
+        }
+        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperB)
+        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcherB)
+        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key") { config in
+            config.impressionsQueueSize = 100_000
+            config.impressionsChunkSize = 100_000
+        }
+
+        // Client B also generates its own impressions (separate coordinator writes).
+        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
+
+        // Wait for all async inserts to drain on both contexts.
+        usleep(5_000_000)
+
+        // Explicit flush on both to post any remaining impressions.
+        clientA.flush()
+        clientB.flush()
+
+        // Wait for flushes + HTTP + deletes to settle.
+        usleep(5_000_000)
+
+        // One more flush round in case deletes caused SQLITE_BUSY on prior flush saves,
+        // leaving some impressions un-deleted and re-poppable.
+        clientA.flush()
+        clientB.flush()
+        usleep(3_000_000)
+
+        // --- Verification ---
+        // Use a FRESH coordinator to get a clean view of the SQLite file.
+        guard let helperVerify = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create verification DB helper")
+            return
+        }
+        let dbVerify = TestingHelper.createTestDatabase(name: databaseName, helper: helperVerify)
+        let finalDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
+                                                         status: StorageRecordStatus.active,
+                                                         maxRows: 1_000_000).count
+
+        var finalAPosted = 0
+        var finalBPosted = 0
+        postQueue.sync {
+            finalAPosted = clientAPostCount
+            finalBPosted = clientBPostCount
+        }
+
+        let totalAccountedFor = finalAPosted + finalBPosted + finalDbCount
+        let expectedTotal = evaluationCountA + evaluationCountB
+
+        print("SplitSDK - TWO_COORD clientA_posted=\(finalAPosted), clientB_posted=\(finalBPosted), "
+            + "db_remaining=\(finalDbCount), total_accounted=\(totalAccountedFor), expected=\(expectedTotal)")
+
+        // Core assertion: no impressions lost.
+        // Every impression must be either posted (by A or B) or still in the DB.
+        // Duplicates across clients are acceptable (both may post the same rows
+        // because pop() is read-only on this branch).
+        XCTAssertGreaterThanOrEqual(totalAccountedFor, expectedTotal,
+            "All impressions must be accounted for: "
+            + "posted_A(\(finalAPosted)) + posted_B(\(finalBPosted)) + db(\(finalDbCount)) "
+            + "should be >= expected(\(expectedTotal))")
+
+        cleanupClient(clientA)
+        cleanupClient(clientB)
+        removeDatabaseFiles(databaseName: databaseName)
+    }
 }

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -166,6 +166,8 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
      And the test waits for the HTTP post to start
      And destroy() is called while the HTTP response is still blocked
      Then all impressions are accounted for: either posted or still in DB (recoverable).
+
+     This scenario also applies to app being killed during in-flight post.
      */
     func testImpressionsNotLostWhenDestroyedDuringInflightPost() {
         let databaseName = "impressions_orphan_destroy_e2e"
@@ -194,10 +196,9 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
         // Verify impressions are in DB
         let impressionsBeforeFlush = queryImpressionCount()
-        print("SplitSDK - ORPHAN_TEST impressionsBeforeFlush=\(impressionsBeforeFlush)")
         XCTAssertEqual(evaluationCount, impressionsBeforeFlush, "All impressions should be in DB before flush")
 
-        // Trigger flush — this will pop() rows (marking them deleted) and start HTTP post
+        // Trigger flush
         client.flush()
         wait(for: [impressionPostStarted], timeout: 10)
 
@@ -208,8 +209,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         let impressionsAfterDestroy = queryImpressionCount()
         var postReceivedAfterDestroy = 0
         postQueue.sync { postReceivedAfterDestroy = postReceivedCount }
-
-        print("SplitSDK - ORPHAN_TEST impressionsAfterDestroy=\(impressionsAfterDestroy), postReceivedAfterDestroy=\(postReceivedAfterDestroy), evaluationCount=\(evaluationCount)")
 
         // All impressions must be accounted for: either posted or still in DB
         // so a future flush can retry them.
@@ -226,7 +225,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
     /**
      Scenario: a second client on the same DB recovers orphaned impressions from the first
 
-     This is a variant of testImpressionsNotLostWhenDestroyedDuringInflightPost.
      After Client A is destroyed during an in-flight post, its impressions remain in
      the database. A second factory/client is created on the same database. Client B
      does its own evaluations and flushes. We verify that:
@@ -291,7 +289,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
         // Verify Client A's impressions are still in DB
         let impressionsAfterDestroy = queryImpressionCount()
-        print("SplitSDK - ORPHAN_NEW_CLIENT impressionsAfterDestroy=\(impressionsAfterDestroy)")
 
         // --- Client B phase ---
         isClientBPhase = true
@@ -303,9 +300,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         usleep(2_000_000)
 
         // Flush Client B
-        // Client B is only expected to post impressions that are ACTIVE in the DB at startup
-        // (leftover from Client A) plus its own generated impressions. Impressions already
-        // sent by Client A's in-flight request are not expected to be re-posted by Client B.
         expectedPostedByB = impressionsAfterDestroy + evaluationCountB
         clientB.flush()
         wait(for: [clientBPostedExp], timeout: 15)
@@ -320,8 +314,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         }
         let finalImpressions = queryImpressionCount()
 
-        print("SplitSDK - ORPHAN_NEW_CLIENT clientAPosted=\(finalClientAPostCount), clientBPosted=\(finalClientBPostCount), finalImpressions=\(finalImpressions)")
-
         // Client B should post leftover ACTIVE impressions from Client A plus its own.
         XCTAssertEqual(impressionsAfterDestroy + evaluationCountB, finalClientBPostCount,
                        "Client B should post its own impressions plus active leftover impressions from Client A")
@@ -334,117 +326,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         XCTAssertEqual(0, finalImpressions,
                        "No impressions should remain in DB after Client B flushes")
 
-        removeDatabaseFiles(databaseName: databaseName)
-    }
-
-    /**
-     Scenario: a second client recovers impressions that failed to post from the first (no interruption)
-
-     Given Client A generates impressions and flushes
-     And the impressions HTTP POST fails with a 500 error (not interrupted)
-     And the impressions remain in the database after the failed flush
-     And Client A is destroyed normally after the failed flush completes
-     When a second factory/client (Client B) is created on the same database
-     And Client B generates its own impressions and flushes
-     Then Client B posts both Client A's recovered impressions and its own
-     And no impressions remain in the database.
-     */
-    func testFailedImpressionsRecoveredByNewClient() {
-        let databaseName = "impressions_failed_recovery_e2e"
-        let clientAPostAttempted = XCTestExpectation(description: "Client A post attempted")
-        let clientBPostedAllExp = XCTestExpectation(description: "Client B posted all impressions")
-
-        let postQueue = DispatchQueue(label: "failed-recovery-post-queue")
-        var isClientBPhase = false
-        var clientBPostedCount = 0
-        var clientBExpFulfilled = false
-
-        let evaluationCountA = 50
-        let evaluationCountB = 20
-        let expectedTotalPostedByB = evaluationCountA + evaluationCountB
-
-        let dispatcher = buildOrphanTestDispatcher { request in
-            if !isClientBPhase {
-                // Client A phase: fail the POST with 500 (should be recovered by setActive()).
-                clientAPostAttempted.fulfill()
-                return TestDispatcherResponse(code: 500)
-            }
-
-            // Client B phase: succeed and count all impressions (Client A recovered + Client B generated).
-            postQueue.sync {
-                clientBPostedCount += self.parseImpressionCount(from: request)
-                if !clientBExpFulfilled && clientBPostedCount >= expectedTotalPostedByB {
-                    clientBExpFulfilled = true
-                    clientBPostedAllExp.fulfill()
-                }
-            }
-            return TestDispatcherResponse(code: 200)
-        }
-
-        // --- Client A phase ---
-        setupOrphanTestDatabase(name: databaseName)
-        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcher)
-        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey) { config in
-            // Deterministic: avoid queue-size-triggered flushes and keep A in a single chunk.
-            config.impressionsQueueSize = 10_000
-            config.impressionsChunkSize = 100
-        }
-
-        generateImpressions(client: clientA, count: evaluationCountA)
-        usleep(2_000_000)
-
-        clientA.flush()
-        wait(for: [clientAPostAttempted], timeout: 10)
-
-        // Wait until impressions are back in DB after failed POST.
-        let restoreDeadline = Date().timeIntervalSince1970 + 10.0
-        while Date().timeIntervalSince1970 < restoreDeadline {
-            let count = queryImpressionCount()
-            if count == evaluationCountA {
-                break
-            }
-            usleep(200_000)
-        }
-
-        let impressionsAfterFailedFlush = queryImpressionCount()
-        XCTAssertEqual(evaluationCountA, impressionsAfterFailedFlush,
-                       "All impressions should still be in DB after failed POST")
-
-        cleanupClient(clientA)
-
-        // --- Client B phase ---
-        isClientBPhase = true
-        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcher)
-        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key") { config in
-            config.impressionsQueueSize = 10_000
-            config.impressionsChunkSize = 100
-        }
-
-        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
-        usleep(2_000_000)
-
-        clientB.flush()
-        wait(for: [clientBPostedAllExp], timeout: 15)
-
-        // Wait until DB drains after successful post.
-        let drainDeadline = Date().timeIntervalSince1970 + 10.0
-        while Date().timeIntervalSince1970 < drainDeadline {
-            let count = queryImpressionCount()
-            if count == 0 {
-                break
-            }
-            usleep(200_000)
-        }
-
-        postQueue.sync {
-            XCTAssertEqual(expectedTotalPostedByB, clientBPostedCount,
-                           "Client B should post both Client A's recovered and its own impressions")
-        }
-
-        let finalImpressions = queryImpressionCount()
-        XCTAssertEqual(0, finalImpressions, "No impressions should remain in DB after successful flush")
-
-        cleanupClient(clientB)
         removeDatabaseFiles(databaseName: databaseName)
     }
 
@@ -472,7 +353,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
         wait(for: [impExp!], timeout: 10)
 
-        // Verify properties in request body
+        // Verify request body
         XCTAssertFalse(requestBodies.isEmpty, "Request bodies should not be empty")
 
         // Check if properties are included in the request body as a stringified JSON
@@ -483,7 +364,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
         // Check if the properties are properly stringified
         let containsPropertiesValue = requestBodies.contains { body in
-            print(body)
             return body.contains("\\\"test\\\":\\\"value\\\"") && body.contains("\\\"number\\\":123")
         }
         XCTAssertTrue(containsPropertiesValue, "Request body should contain the correct property values")
@@ -843,20 +723,15 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         return splitJson
     }
 
-    // MARK: - Two-Coordinator Collision Test & Helpers
-
     /**
-     Scenario: back-to-back factory creation on the same SQLite file.
-     Replicates the customer flow exactly:
+     Scenario: consecutive factory creation on the same SQLite file.
 
-       1. Create Client A (factory A, file-backed DB)
-       2. Client A does many getTreatment evaluations with properties (no dedup →
-          one async insert + save() per evaluation, still queuing on context A)
+       1. Create Client A (factory A)
+       2. Client A does many getTreatment evaluations with properties
        3. Client A calls flush()
-       4. IMMEDIATELY create Client B (factory B, same SQLite file, separate
-          NSPersistentStoreCoordinator)
-       5. Client B's periodic timer fires at deadline:0
-       6. Client B does its own evaluations (more concurrent writes).
+       4. Immediately create Client B (factory B, same SQLite file)
+       5. Client B's periodic timer fires immediately
+       6. Client B does its own evaluations.
      */
     func testBackToBackFactoriesOnSameDbFileNoImpressionLoss() {
         let databaseName = "impressions_two_coordinators_e2e"
@@ -885,7 +760,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
             return TestDispatcherResponse(code: 200)
         }
 
-        // --- Client A: first NSPersistentStoreCoordinator on file-backed DB ---
+        // Client A
         guard let helperA = CoreDataHelperBuilder.build(databaseName: databaseName) else {
             XCTFail("Failed to create DB helper for Client A")
             return
@@ -898,19 +773,16 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
             config.impressionRefreshRate = 5
         }
 
-        // Step 2: Client A does many evaluations — async inserts still queuing
-        // on context A's serial queue.
+        // Step 2: Client A does many evaluations. Async inserts still queuing
         generateImpressions(client: clientA, count: evaluationCountA)
 
-        // Step 3: Client A calls flush() — async (DispatchQueue.general → flushQueue).
-        // Inserts are likely still in progress.
+        // Step 3: Client A calls flush(). Async.
+        // Inserts still in progress.
         clientA.flush()
 
-        // Step 4: IMMEDIATELY create Client B — NO SLEEP.
+        // Step 4: IMMEDIATELY create Client B.
         // Client A's inserts are still running. Client B opens a second
         // NSPersistentStoreCoordinator on the same SQLite file.
-        // Client B's periodic timer fires at deadline:0 → pop → post → delete.
-        // Those writes collide with Client A's ongoing insert save() calls.
         guard let helperB = CoreDataHelperBuilder.build(databaseName: databaseName) else {
             XCTFail("Failed to create DB helper for Client B")
             return
@@ -938,7 +810,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         clientB.flush()
         usleep(3_000_000)
 
-        // --- Verification ---
         // Use a FRESH coordinator to get a clean view of the SQLite file.
         guard let helperVerify = CoreDataHelperBuilder.build(databaseName: databaseName) else {
             XCTFail("Failed to create verification DB helper")
@@ -950,10 +821,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         let activeDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
                                                           status: StorageRecordStatus.active,
                                                           maxRows: 1_000_000).count
-        // Count deleted impressions (stuck — lost if nobody recovers them)
-//        let deletedDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
-//                                                           status: StorageRecordStatus.deleted,
-//                                                           maxRows: 1_000_000).count
 
         var finalAPosted = 0
         var finalBPosted = 0
@@ -966,13 +833,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         let totalAccountedFor = totalPosted + activeDbCount
         let expectedTotal = evaluationCountA + evaluationCountB
 
-        print("SplitSDK - TWO_COORD clientA_posted=\(finalAPosted), clientB_posted=\(finalBPosted), "
-            + "db_active=\(activeDbCount), "
-            + "total_accounted=\(totalAccountedFor), expected=\(expectedTotal)")
-
         // Every impression must be either posted or recoverable (active in DB).
-        // Impressions stuck as "deleted" are NOT recoverable — they will never be
-        // popped again (status=active filter skips them).
         XCTAssertGreaterThanOrEqual(totalAccountedFor, expectedTotal,
             "All impressions must be accounted for: "
             + "posted(\(totalPosted)) + db_active(\(activeDbCount)) "
@@ -982,8 +843,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         cleanupClient(clientB)
         removeDatabaseFiles(databaseName: databaseName)
     }
-
-    // MARK: - Orphan Test Helpers
 
     /// Parses the number of individual impressions from an HTTP request body.
     private func parseImpressionCount(from request: HttpDataRequest) -> Int {

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -843,6 +843,162 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         return splitJson
     }
 
+    // MARK: - Two-Coordinator Collision Test & Helpers
+
+    /**
+     Scenario: back-to-back factory creation on the same SQLite file.
+     Replicates the customer flow exactly:
+
+       1. Create Client A (factory A, file-backed DB)
+       2. Client A does many getTreatment evaluations with properties (no dedup →
+          one async insert + save() per evaluation, still queuing on context A)
+       3. Client A calls flush() (async — two dispatch hops before actual work)
+       4. IMMEDIATELY create Client B (factory B, same SQLite file, separate
+          NSPersistentStoreCoordinator). No sleep, no waiting.
+       5. Client B's periodic timer fires at deadline:0 → pop → post → delete.
+          These delete save() calls collide with Client A's still-running insert
+          save() calls at the SQLite write lock (SQLITE_BUSY, no busy-wait).
+       6. Client B does its own evaluations (more concurrent writes).
+
+     On the old branch (with status-based pop):
+       - pop() marks rows as "deleted" → if HTTP fails, setActive() recovery
+         save() can hit SQLITE_BUSY → rows stuck as "deleted" → LOST.
+       - Even with HTTP success, the status update save() and delete save()
+         compete with the other coordinator's writes.
+
+     On the new branch (no status): pop() is read-only, delete only after
+     successful POST, no recovery needed. Should pass.
+     */
+    func testBackToBackFactoriesOnSameDbFileNoImpressionLoss() {
+        let databaseName = "impressions_two_coordinators_e2e"
+        removeDatabaseFiles(databaseName: databaseName)
+
+        let postQueue = DispatchQueue(label: "two-coord-post-queue")
+        var clientAPostCount = 0
+        var clientBPostCount = 0
+
+        let evaluationCountA = 30000
+        let evaluationCountB = 6000
+
+        // Client A dispatcher: count posted impressions
+        let dispatcherA = buildOrphanTestDispatcher { request in
+            postQueue.sync {
+                clientAPostCount += self.parseImpressionCount(from: request)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        // Client B dispatcher: count posted impressions
+        let dispatcherB = buildOrphanTestDispatcher { request in
+            postQueue.sync {
+                clientBPostCount += self.parseImpressionCount(from: request)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        // --- Client A: first NSPersistentStoreCoordinator on file-backed DB ---
+        guard let helperA = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create DB helper for Client A")
+            return
+        }
+        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperA)
+        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcherA)
+        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey) { config in
+            config.impressionsQueueSize = 100_000
+            config.impressionsChunkSize = 100_000
+            config.impressionRefreshRate = 5
+        }
+
+        // Step 2: Client A does many evaluations — async inserts still queuing
+        // on context A's serial queue.
+        generateImpressions(client: clientA, count: evaluationCountA)
+
+        // Step 3: Client A calls flush() — async (DispatchQueue.general → flushQueue).
+        // Inserts are likely still in progress.
+        clientA.flush()
+
+        // Step 4: IMMEDIATELY create Client B — NO SLEEP.
+        // Client A's inserts are still running. Client B opens a second
+        // NSPersistentStoreCoordinator on the same SQLite file.
+        // Client B's periodic timer fires at deadline:0 → pop → post → delete.
+        // Those writes collide with Client A's ongoing insert save() calls.
+        guard let helperB = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create DB helper for Client B")
+            return
+        }
+        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperB)
+        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcherB)
+        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key") { config in
+            config.impressionsQueueSize = 100_000
+            config.impressionsChunkSize = 100_000
+            config.impressionRefreshRate = 5
+        }
+
+        // Step 5-6: Client B does its own evaluations (more concurrent writes).
+        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
+
+        // Wait for async inserts + flush cycles to settle on both coordinators.
+        usleep(5_000_000)
+
+        // Extra flush rounds to drain anything remaining.
+        clientA.flush()
+        clientB.flush()
+        usleep(5_000_000)
+
+        clientA.flush()
+        clientB.flush()
+        usleep(3_000_000)
+
+        // --- Verification ---
+        // Use a FRESH coordinator to get a clean view of the SQLite file.
+        guard let helperVerify = CoreDataHelperBuilder.build(databaseName: databaseName) else {
+            XCTFail("Failed to create verification DB helper")
+            return
+        }
+        let dbVerify = TestingHelper.createTestDatabase(name: databaseName, helper: helperVerify)
+
+        // Count active impressions (recoverable)
+        let activeDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
+                                                          status: StorageRecordStatus.active,
+                                                          maxRows: 1_000_000).count
+        // Count deleted impressions (stuck — lost if nobody recovers them)
+        let deletedDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
+                                                           status: StorageRecordStatus.deleted,
+                                                           maxRows: 1_000_000).count
+
+        var finalAPosted = 0
+        var finalBPosted = 0
+        postQueue.sync {
+            finalAPosted = clientAPostCount
+            finalBPosted = clientBPostCount
+        }
+
+        // Both clients' HTTP succeeds, so all posted impressions reached the server.
+        // But impressions stuck as "deleted" in the DB were popped (marked deleted)
+        // yet their delete save() may have failed (SQLITE_BUSY) — they could be
+        // re-posted on a future flush, OR they may be orphaned if the context is gone.
+        let totalPosted = finalAPosted + finalBPosted
+        let totalAccountedFor = totalPosted + activeDbCount
+        let expectedTotal = evaluationCountA + evaluationCountB
+
+        print("SplitSDK - TWO_COORD clientA_posted=\(finalAPosted), clientB_posted=\(finalBPosted), "
+            + "db_active=\(activeDbCount), db_deleted=\(deletedDbCount), "
+            + "total_accounted=\(totalAccountedFor), expected=\(expectedTotal)")
+
+        // Every impression must be either posted or recoverable (active in DB).
+        // Impressions stuck as "deleted" are NOT recoverable — they will never be
+        // popped again (status=active filter skips them).
+        XCTAssertGreaterThanOrEqual(totalAccountedFor, expectedTotal,
+            "All impressions must be accounted for: "
+            + "posted(\(totalPosted)) + db_active(\(activeDbCount)) "
+            + "should be >= expected(\(expectedTotal)). "
+            + "db_deleted(\(deletedDbCount)) rows are STUCK and LOST.")
+
+        cleanupClient(clientA)
+        cleanupClient(clientB)
+        removeDatabaseFiles(databaseName: databaseName)
+    }
+
     // MARK: - Orphan Test Helpers
 
     /// Parses the number of individual impressions from an HTTP request body.
@@ -946,147 +1102,4 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         return db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.active, maxRows: 1_000_000).count
     }
 
-    // MARK: - Two-Coordinator Collision Test
-
-        /**
-         Scenario: back-to-back factory creation on the same SQLite file — no impression loss
-         despite concurrent insert/delete across uncoordinated NSPersistentStoreCoordinators.
-
-         Replicates the reported customer scenario:
-         - Client A (factory A) does many getTreatment evaluations with impression properties.
-           Each evaluation inserts one impression with an individual save() — no deduplication
-           because properties make each impression unique.
-         - Client A calls flush().
-         - Client B (factory B, same SDK key + same DB prefix) is created "back to back".
-           Each factory creates its own NSPersistentStoreCoordinator, both pointing at the
-           same SQLite file.
-         - Client B's periodic timer fires immediately (deadline: 0) — it pops committed
-           impressions from SQLite, posts them, and deletes them.
-         - The collision: Client A's ongoing insert save() and Client B's delete save()
-           compete for the SQLite write lock. With no busy-timeout configured,
-           the loser gets SQLITE_BUSY and CoreDataHelper.save() swallows the error.
-
-         The test verifies that despite this contention, all impressions are accounted for:
-         either posted to the server or still recoverable in the database.
-         */
-    func testBackToBackFactoriesOnSameDbFileNoImpressionLoss() {
-        let databaseName = "impressions_two_coordinators_e2e"
-        removeDatabaseFiles(databaseName: databaseName)
-
-        let postQueue = DispatchQueue(label: "two-coord-post-queue")
-        var clientAPostCount = 0
-        var clientBPostCount = 0
-
-        let evaluationCountA = 200
-        let evaluationCountB = 50
-
-        // Client A dispatcher: count posted impressions
-        let dispatcherA = buildOrphanTestDispatcher { request in
-            postQueue.sync {
-                clientAPostCount += self.parseImpressionCount(from: request)
-            }
-            return TestDispatcherResponse(code: 200)
-        }
-
-        // Client B dispatcher: count posted impressions
-        let dispatcherB = buildOrphanTestDispatcher { request in
-            postQueue.sync {
-                clientBPostCount += self.parseImpressionCount(from: request)
-            }
-            return TestDispatcherResponse(code: 200)
-        }
-
-        // --- Client A: first NSPersistentStoreCoordinator on file-backed DB ---
-        guard let helperA = CoreDataHelperBuilder.build(databaseName: databaseName) else {
-            XCTFail("Failed to create DB helper for Client A")
-            return
-        }
-        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperA)
-        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcherA)
-        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey) { config in
-            config.impressionsQueueSize = 100_000
-            config.impressionsChunkSize = 100_000
-        }
-
-        // Client A generates many impressions. Each getTreatment triggers an async
-        // insert (context.perform { create + save() }). The saves are queued on
-        // Context A's serial queue and will still be executing after this returns.
-        generateImpressions(client: clientA, count: evaluationCountA)
-
-        // Client A calls flush() — async (DispatchQueue.general → flushQueue).
-        // Inserts may still be in progress on Context A's queue.
-        clientA.flush()
-
-        // --- Client B: SECOND NSPersistentStoreCoordinator on SAME SQLite file ---
-        // Created "back to back" while Client A is still inserting.
-        // Client B's periodic timer fires immediately (deadline: 0). Its pop() reads
-        // from SQLite; its post + delete save() may collide with Client A's ongoing
-        // insert save() at the SQLite write lock (SQLITE_BUSY, no busy-wait).
-        guard let helperB = CoreDataHelperBuilder.build(databaseName: databaseName) else {
-            XCTFail("Failed to create DB helper for Client B")
-            return
-        }
-        db = TestingHelper.createTestDatabase(name: databaseName, helper: helperB)
-        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcherB)
-        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key") { config in
-            config.impressionsQueueSize = 100_000
-            config.impressionsChunkSize = 100_000
-        }
-
-        // Client B also generates its own impressions (separate coordinator writes).
-        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
-
-        // Wait for all async inserts to drain on both contexts.
-        usleep(5_000_000)
-
-        // Explicit flush on both to post any remaining impressions.
-        clientA.flush()
-        clientB.flush()
-
-        // Wait for flushes + HTTP + deletes to settle.
-        usleep(5_000_000)
-
-        // One more flush round in case deletes caused SQLITE_BUSY on prior flush saves,
-        // leaving some impressions un-deleted and re-poppable.
-        clientA.flush()
-        clientB.flush()
-        usleep(3_000_000)
-
-        // --- Verification ---
-        // Use a FRESH coordinator to get a clean view of the SQLite file.
-        guard let helperVerify = CoreDataHelperBuilder.build(databaseName: databaseName) else {
-            XCTFail("Failed to create verification DB helper")
-            return
-        }
-        let dbVerify = TestingHelper.createTestDatabase(name: databaseName, helper: helperVerify)
-        let finalDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
-                                                         status: StorageRecordStatus.active,
-                                                         maxRows: 1_000_000).count
-
-        var finalAPosted = 0
-        var finalBPosted = 0
-        postQueue.sync {
-            finalAPosted = clientAPostCount
-            finalBPosted = clientBPostCount
-        }
-
-        let totalAccountedFor = finalAPosted + finalBPosted + finalDbCount
-        let expectedTotal = evaluationCountA + evaluationCountB
-
-        print("SplitSDK - TWO_COORD clientA_posted=\(finalAPosted), clientB_posted=\(finalBPosted), "
-            + "db_remaining=\(finalDbCount), total_accounted=\(totalAccountedFor), expected=\(expectedTotal)")
-
-        // Core assertion: no impressions lost.
-        // Every impression must be either posted (by A or B) or still in the DB.
-        // Duplicates across clients are acceptable (both may post the same rows
-        // because pop() is read-only on this branch).
-        XCTAssertGreaterThanOrEqual(totalAccountedFor, expectedTotal,
-            "All impressions must be accounted for: "
-            + "posted_A(\(finalAPosted)) + posted_B(\(finalBPosted)) + db(\(finalDbCount)) "
-            + "should be >= expected(\(expectedTotal))")
-
-        cleanupClient(clientA)
-        cleanupClient(clientB)
-        removeDatabaseFiles(databaseName: databaseName)
-    }
 }

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -852,22 +852,11 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
        1. Create Client A (factory A, file-backed DB)
        2. Client A does many getTreatment evaluations with properties (no dedup →
           one async insert + save() per evaluation, still queuing on context A)
-       3. Client A calls flush() (async — two dispatch hops before actual work)
+       3. Client A calls flush()
        4. IMMEDIATELY create Client B (factory B, same SQLite file, separate
-          NSPersistentStoreCoordinator). No sleep, no waiting.
-       5. Client B's periodic timer fires at deadline:0 → pop → post → delete.
-          These delete save() calls collide with Client A's still-running insert
-          save() calls at the SQLite write lock (SQLITE_BUSY, no busy-wait).
+          NSPersistentStoreCoordinator)
+       5. Client B's periodic timer fires at deadline:0
        6. Client B does its own evaluations (more concurrent writes).
-
-     On the old branch (with status-based pop):
-       - pop() marks rows as "deleted" → if HTTP fails, setActive() recovery
-         save() can hit SQLITE_BUSY → rows stuck as "deleted" → LOST.
-       - Even with HTTP success, the status update save() and delete save()
-         compete with the other coordinator's writes.
-
-     On the new branch (no status): pop() is read-only, delete only after
-     successful POST, no recovery needed. Should pass.
      */
     func testBackToBackFactoriesOnSameDbFileNoImpressionLoss() {
         let databaseName = "impressions_two_coordinators_e2e"
@@ -962,9 +951,9 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
                                                           status: StorageRecordStatus.active,
                                                           maxRows: 1_000_000).count
         // Count deleted impressions (stuck — lost if nobody recovers them)
-        let deletedDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
-                                                           status: StorageRecordStatus.deleted,
-                                                           maxRows: 1_000_000).count
+//        let deletedDbCount = dbVerify.impressionDao.getBy(createdAt: 0,
+//                                                           status: StorageRecordStatus.deleted,
+//                                                           maxRows: 1_000_000).count
 
         var finalAPosted = 0
         var finalBPosted = 0
@@ -973,16 +962,12 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
             finalBPosted = clientBPostCount
         }
 
-        // Both clients' HTTP succeeds, so all posted impressions reached the server.
-        // But impressions stuck as "deleted" in the DB were popped (marked deleted)
-        // yet their delete save() may have failed (SQLITE_BUSY) — they could be
-        // re-posted on a future flush, OR they may be orphaned if the context is gone.
         let totalPosted = finalAPosted + finalBPosted
         let totalAccountedFor = totalPosted + activeDbCount
         let expectedTotal = evaluationCountA + evaluationCountB
 
         print("SplitSDK - TWO_COORD clientA_posted=\(finalAPosted), clientB_posted=\(finalBPosted), "
-            + "db_active=\(activeDbCount), db_deleted=\(deletedDbCount), "
+            + "db_active=\(activeDbCount), "
             + "total_accounted=\(totalAccountedFor), expected=\(expectedTotal)")
 
         // Every impression must be either posted or recoverable (active in DB).
@@ -991,8 +976,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         XCTAssertGreaterThanOrEqual(totalAccountedFor, expectedTotal,
             "All impressions must be accounted for: "
             + "posted(\(totalPosted)) + db_active(\(activeDbCount)) "
-            + "should be >= expected(\(expectedTotal)). "
-            + "db_deleted(\(deletedDbCount)) rows are STUCK and LOST.")
+            + "should be >= expected(\(expectedTotal)).")
 
         cleanupClient(clientA)
         cleanupClient(clientB)

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -49,17 +49,12 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
      And impressions refresh rate set to 5 seconds
      And an impressions endpoint spy that counts posted impressions
      When getTreatment is called in a loop with EvaluationOptions(properties)
-     And the loop stops early at a random iteration (between 20% and 100% of total) with a flush
+     And the loop stops early at a random iteration
      Or the loop completes all iterations and a fallback flush is triggered
      Then each iteration returns the expected treatment
      And elapsed time is greater than zero
      And impression listener count equals tracked evaluations
-     And tracked evaluations equal db impressions plus posted impressions
-
-     Notes:
-     - Posted impressions are removed from the impressions table after successful post.
-     - The random early exit varies the number of evaluations to exercise different batch sizes.
-     - Exactly one explicit flush is performed per test run (random or fallback).
+     And tracked evaluations is less than db impressions plus posted impressions (no loss)
      */
     func testTreatmentLoopWithImpressionPropertiesAndRandomFlushAccounting() {
         let iterations = 10000
@@ -170,8 +165,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
      And flush() is called to trigger impression posting
      And the test waits for the HTTP post to start
      And destroy() is called while the HTTP response is still blocked
-     Then no impressions should be orphaned in deleted status
-     And all impressions are accounted for: either posted or still active (recoverable).
+     Then all impressions are accounted for: either posted or still in DB (recoverable).
      */
     func testImpressionsNotLostWhenDestroyedDuringInflightPost() {
         let databaseName = "impressions_orphan_destroy_e2e"
@@ -198,10 +192,10 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         generateImpressions(client: client, count: evaluationCount)
         usleep(2_000_000)
 
-        // Verify impressions are in DB with active status
-        let (activeBeforeFlush, _) = queryImpressionCounts()
-        print("SplitSDK - ORPHAN_TEST activeBeforeFlush=\(activeBeforeFlush)")
-        XCTAssertEqual(evaluationCount, activeBeforeFlush, "All impressions should be active before flush")
+        // Verify impressions are in DB
+        let impressionsBeforeFlush = queryImpressionCount()
+        print("SplitSDK - ORPHAN_TEST impressionsBeforeFlush=\(impressionsBeforeFlush)")
+        XCTAssertEqual(evaluationCount, impressionsBeforeFlush, "All impressions should be in DB before flush")
 
         // Trigger flush — this will pop() rows (marking them deleted) and start HTTP post
         client.flush()
@@ -211,18 +205,16 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         cleanupClient(client)
 
         // Check DB and post state BEFORE unblocking the HTTP response.
-        let (activeAfterDestroy, deletedAfterDestroy) = queryImpressionCounts()
+        let impressionsAfterDestroy = queryImpressionCount()
         var postReceivedAfterDestroy = 0
         postQueue.sync { postReceivedAfterDestroy = postReceivedCount }
 
-        print("SplitSDK - ORPHAN_TEST activeAfterDestroy=\(activeAfterDestroy), deletedAfterDestroy=\(deletedAfterDestroy), postReceivedAfterDestroy=\(postReceivedAfterDestroy), evaluationCount=\(evaluationCount)")
+        print("SplitSDK - ORPHAN_TEST impressionsAfterDestroy=\(impressionsAfterDestroy), postReceivedAfterDestroy=\(postReceivedAfterDestroy), evaluationCount=\(evaluationCount)")
 
-        // No impressions should be stuck in deleted status — they must be either
-        // posted successfully or restored to active so a future flush can retry them.
-        XCTAssertEqual(0, deletedAfterDestroy,
-                       "No impressions should be orphaned in deleted status")
-        XCTAssertEqual(evaluationCount, activeAfterDestroy + postReceivedAfterDestroy,
-                       "All impressions must be accounted for: either posted or still active")
+        // All impressions must be accounted for: either posted or still in DB
+        // so a future flush can retry them.
+        XCTAssertEqual(evaluationCount, impressionsAfterDestroy + postReceivedAfterDestroy,
+                       "All impressions must be accounted for: either posted or still in DB")
 
         // Unblock the HTTP response so the blocked worker thread can finish
         impressionPostSemaphore.signal()
@@ -235,21 +227,23 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
      Scenario: a second client on the same DB recovers orphaned impressions from the first
 
      This is a variant of testImpressionsNotLostWhenDestroyedDuringInflightPost.
-     After Client A's impressions are orphaned (stuck in deleted status), a second
-     factory/client is created on the same database. Client B does its own evaluations
-     and flushes. We verify that:
-     - Client B posts both its OWN and the recovered orphaned impressions from Client A
-     - No impressions remain in deleted status after Client B flushes
+     After Client A is destroyed during an in-flight post, its impressions remain in
+     the database. A second factory/client is created on the same database. Client B
+     does its own evaluations and flushes. We verify that:
+     - Client B posts both its OWN and the recovered impressions from Client A
+     - No impressions remain in the database after Client B flushes
      */
     func testOrphanedImpressionsRecoveredByNewClient() {
         let databaseName = "impressions_orphan_new_client_e2e"
         let impressionPostStarted = XCTestExpectation(description: "Impression post started")
         let impressionPostSemaphore = DispatchSemaphore(value: 0)
-        let clientBPostedExp = XCTestExpectation(description: "Client B impressions posted")
+        let clientBPostedExp = XCTestExpectation(description: "Client B posted expected impressions")
         var postReceivedCount = 0
         var clientBPostReceivedCount = 0
         var isClientBPhase = false
         let postQueue = DispatchQueue(label: "orphan-new-client-post-queue")
+        var expectedPostedByB = 0
+        var clientBPostedExpFulfilled = false
 
         let dispatcher = buildOrphanTestDispatcher { request in
             if !isClientBPhase {
@@ -261,11 +255,16 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
                 }
                 return TestDispatcherResponse(code: 200)
             } else {
-                // Client B phase: respond immediately and count
+                // Client B phase: respond immediately and count until expected total is reached.
                 postQueue.sync {
                     clientBPostReceivedCount += self.parseImpressionCount(from: request)
+                    if !clientBPostedExpFulfilled,
+                       expectedPostedByB > 0,
+                       clientBPostReceivedCount >= expectedPostedByB {
+                        clientBPostedExpFulfilled = true
+                        clientBPostedExp.fulfill()
+                    }
                 }
-                clientBPostedExp.fulfill()
                 return TestDispatcherResponse(code: 200)
             }
         }
@@ -290,9 +289,9 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         impressionPostSemaphore.signal()
         usleep(500_000)
 
-        // Verify Client A's impressions are orphaned
-        let (_, deletedAfterDestroy) = queryImpressionCounts()
-        print("SplitSDK - ORPHAN_NEW_CLIENT deletedAfterDestroy=\(deletedAfterDestroy)")
+        // Verify Client A's impressions are still in DB
+        let impressionsAfterDestroy = queryImpressionCount()
+        print("SplitSDK - ORPHAN_NEW_CLIENT impressionsAfterDestroy=\(impressionsAfterDestroy)")
 
         // --- Client B phase ---
         isClientBPhase = true
@@ -304,24 +303,36 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         usleep(2_000_000)
 
         // Flush Client B
+        // Client B is only expected to post impressions that are ACTIVE in the DB at startup
+        // (leftover from Client A) plus its own generated impressions. Impressions already
+        // sent by Client A's in-flight request are not expected to be re-posted by Client B.
+        expectedPostedByB = impressionsAfterDestroy + evaluationCountB
         clientB.flush()
         wait(for: [clientBPostedExp], timeout: 15)
         usleep(1_000_000)
 
         // Final state
         var finalClientBPostCount = 0
-        postQueue.sync { finalClientBPostCount = clientBPostReceivedCount }
-        let (finalActive, finalDeleted) = queryImpressionCounts()
+        var finalClientAPostCount = 0
+        postQueue.sync {
+            finalClientBPostCount = clientBPostReceivedCount
+            finalClientAPostCount = postReceivedCount
+        }
+        let finalImpressions = queryImpressionCount()
 
-        print("SplitSDK - ORPHAN_NEW_CLIENT clientBPosted=\(finalClientBPostCount), finalActive=\(finalActive), finalDeleted=\(finalDeleted)")
+        print("SplitSDK - ORPHAN_NEW_CLIENT clientAPosted=\(finalClientAPostCount), clientBPosted=\(finalClientBPostCount), finalImpressions=\(finalImpressions)")
 
-        // Client B should have posted ALL impressions: its own + recovered orphans from Client A
-        XCTAssertEqual(evaluationCountA + evaluationCountB, finalClientBPostCount,
-                       "Client B should post both its own and Client A's recovered impressions")
+        // Client B should post leftover ACTIVE impressions from Client A plus its own.
+        XCTAssertEqual(impressionsAfterDestroy + evaluationCountB, finalClientBPostCount,
+                       "Client B should post its own impressions plus active leftover impressions from Client A")
 
-        // No impressions should remain in deleted status
-        XCTAssertEqual(0, finalDeleted,
-                       "No impressions should be stuck in deleted status after Client B flushes")
+        // Across both clients, all evaluations should be accounted for by posted impressions.
+        XCTAssertEqual(evaluationCountA + evaluationCountB, finalClientAPostCount + finalClientBPostCount,
+                       "All impressions should be posted across Client A (in-flight) and Client B (recovered active)")
+
+        // No impressions should remain in DB
+        XCTAssertEqual(0, finalImpressions,
+                       "No impressions should remain in DB after Client B flushes")
 
         removeDatabaseFiles(databaseName: databaseName)
     }
@@ -331,7 +342,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
      Given Client A generates impressions and flushes
      And the impressions HTTP POST fails with a 500 error (not interrupted)
-     And ImpressionsRecorderWorker.setActive() restores them to active status
+     And the impressions remain in the database after the failed flush
      And Client A is destroyed normally after the failed flush completes
      When a second factory/client (Client B) is created on the same database
      And Client B generates its own impressions and flushes
@@ -385,21 +396,19 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         clientA.flush()
         wait(for: [clientAPostAttempted], timeout: 10)
 
-        // Wait until impressions are restored to active by setActive().
+        // Wait until impressions are back in DB after failed POST.
         let restoreDeadline = Date().timeIntervalSince1970 + 10.0
         while Date().timeIntervalSince1970 < restoreDeadline {
-            let (active, deleted) = queryImpressionCounts()
-            if active == evaluationCountA && deleted == 0 {
+            let count = queryImpressionCount()
+            if count == evaluationCountA {
                 break
             }
             usleep(200_000)
         }
 
-        let (activeAfterFailedFlush, deletedAfterFailedFlush) = queryImpressionCounts()
-        XCTAssertEqual(evaluationCountA, activeAfterFailedFlush,
-                       "All impressions should be restored to active after failed POST")
-        XCTAssertEqual(0, deletedAfterFailedFlush,
-                       "No impressions should remain in deleted status after failed POST")
+        let impressionsAfterFailedFlush = queryImpressionCount()
+        XCTAssertEqual(evaluationCountA, impressionsAfterFailedFlush,
+                       "All impressions should still be in DB after failed POST")
 
         cleanupClient(clientA)
 
@@ -420,8 +429,8 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         // Wait until DB drains after successful post.
         let drainDeadline = Date().timeIntervalSince1970 + 10.0
         while Date().timeIntervalSince1970 < drainDeadline {
-            let (active, deleted) = queryImpressionCounts()
-            if active == 0 && deleted == 0 {
+            let count = queryImpressionCount()
+            if count == 0 {
                 break
             }
             usleep(200_000)
@@ -432,9 +441,8 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
                            "Client B should post both Client A's recovered and its own impressions")
         }
 
-        let (finalActive, finalDeleted) = queryImpressionCounts()
-        XCTAssertEqual(0, finalActive, "No active impressions should remain after successful flush")
-        XCTAssertEqual(0, finalDeleted, "No deleted impressions should remain after successful flush")
+        let finalImpressions = queryImpressionCount()
+        XCTAssertEqual(0, finalImpressions, "No impressions should remain in DB after successful flush")
 
         cleanupClient(clientB)
         removeDatabaseFiles(databaseName: databaseName)
@@ -591,7 +599,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         }
 
         // Check the number of impressions recorded
-        let expectedCount = 1
+        let expectedCount = expectDeduplication ? 1 : treatmentTimes
         XCTAssertEqual(expectedCount, impressions[featureName]?.count ?? 0,
                        "Expected \(expectedCount) impressions for feature \(featureName)")
         
@@ -776,9 +784,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
             if request.isImpressionsEndpoint() {
                 self.queue.sync {
-                    if let exp = self.impExp {
-                        exp.fulfill()
-                    }
                     if let body = request.body?.stringRepresentation.utf8 {
                         let bodyString = String(body)
                         self.requestBodies.append(bodyString)
@@ -794,6 +799,9 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
                                 self.impressions.updateValue(imps, forKey: test.testName)
                             }
                         }
+                    }
+                    if let exp = self.impExp {
+                        exp.fulfill()
                     }
                 }
                 return TestDispatcherResponse(code: 200)
@@ -933,10 +941,8 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         }
     }
 
-    /// Queries the database for impression counts grouped by status.
-    private func queryImpressionCounts() -> (active: Int, deleted: Int) {
-        let active = db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.active, maxRows: 1_000_000).count
-        let deleted = db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.deleted, maxRows: 1_000_000).count
-        return (active, deleted)
+    /// Queries the database for total impression count.
+    private func queryImpressionCount() -> Int {
+        return db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.active, maxRows: 1_000_000).count
     }
 }

--- a/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
+++ b/SplitTests/Impressions/ImpressionsPropertiesE2ETest.swift
@@ -27,6 +27,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
     let queue = DispatchQueue(label: "queue", target: .test)
     var db: SplitDatabase!
     var requestBodies: [String] = []
+    var postedImpressionsCount = 0
 
     override func setUp() {
         let session = HttpSessionMock()
@@ -38,6 +39,405 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         sseExp = XCTestExpectation(description: "Sse conn")
         impExp = nil
         requestBodies = []
+        postedImpressionsCount = 0
+    }
+
+    /**
+     Scenario: treatment evaluations with impression properties account for all impressions
+
+     Given an SDK client initialized with mocked split and segment endpoints
+     And impressions refresh rate set to 5 seconds
+     And an impressions endpoint spy that counts posted impressions
+     When getTreatment is called in a loop with EvaluationOptions(properties)
+     And the loop stops early at a random iteration (between 20% and 100% of total) with a flush
+     Or the loop completes all iterations and a fallback flush is triggered
+     Then each iteration returns the expected treatment
+     And elapsed time is greater than zero
+     And impression listener count equals tracked evaluations
+     And tracked evaluations equal db impressions plus posted impressions
+
+     Notes:
+     - Posted impressions are removed from the impressions table after successful post.
+     - The random early exit varies the number of evaluations to exercise different batch sizes.
+     - Exactly one explicit flush is performed per test run (random or fallback).
+     */
+    func testTreatmentLoopWithImpressionPropertiesAndRandomFlushAccounting() {
+        let iterations = 10000
+        let listenerQueue = DispatchQueue(label: "impression-properties-listener-count")
+        var listenerImpressionsCount = 0
+        let client = setupClientFileBacked(
+            mode: "OPTIMIZED",
+            databaseName: "impressions_properties_random_flush_e2e"
+        ) { config in
+            config.impressionRefreshRate = 5
+            config.impressionListener = { _ in
+                listenerQueue.sync {
+                    listenerImpressionsCount += 1
+                }
+            }
+        }
+        let minFlushIteration = max(1, iterations / 5)
+        let flushAtIteration = Int.random(in: minFlushIteration..<iterations)
+        var randomFlushInvoked = false
+
+        var trackedEvaluations = 0
+        var evaluatedIterations = 0
+        let start = Date().timeIntervalSince1970
+        for i in 0..<iterations {
+            let properties: [String: Any] = [
+                "iteration": i,
+                "bucket": i % 10,
+                "is_even": i % 2 == 0,
+                "tag": "perf_\(i)"
+            ]
+            let evalOptions = EvaluationOptions(properties: properties)
+            let treatment = client.getTreatment("FACUNDO_TEST", attributes: nil, evaluationOptions: evalOptions)
+            XCTAssertTrue(treatment == "off",
+                          "Unexpected treatment value: \(treatment)")
+            if treatment == "off" {
+                trackedEvaluations += 1
+            }
+            evaluatedIterations += 1
+            if !randomFlushInvoked && i >= flushAtIteration && Int.random(in: 0..<100) < 20 {
+                randomFlushInvoked = true
+                client.flush()
+                break
+            }
+        }
+        let elapsedMs = (Date().timeIntervalSince1970 - start) * 1000.0
+
+        // Ensure exactly one flush per test run
+        if !randomFlushInvoked {
+            client.flush()
+        }
+
+        var dbCount = 0
+        var postedCount = 0
+        var lastDbCount = -1
+        var lastPostedCount = -1
+        var stableSamples = 0
+        let quiescenceStart = Date().timeIntervalSince1970
+        let quiescenceDeadline = Date().timeIntervalSince1970 + 60.0
+        while Date().timeIntervalSince1970 < quiescenceDeadline {
+            dbCount = db.impressionDao.getBy(createdAt: 0,
+                                             status: StorageRecordStatus.active,
+                                             maxRows: 1_000_000).count
+            queue.sync {
+                postedCount = postedImpressionsCount
+            }
+
+            if dbCount == lastDbCount && postedCount == lastPostedCount {
+                stableSamples += 1
+                if stableSamples >= 10 {
+                    break
+                }
+            } else {
+                stableSamples = 0
+                lastDbCount = dbCount
+                lastPostedCount = postedCount
+            }
+            usleep(500_000)
+        }
+        _ = (Date().timeIntervalSince1970 - quiescenceStart) * 1000.0
+
+        dbCount = db.impressionDao.getBy(createdAt: 0,
+                                         status: StorageRecordStatus.active,
+                                         maxRows: 1_000_000).count
+        queue.sync {
+            postedCount = postedImpressionsCount
+        }
+        var listenerCount = 0
+        listenerQueue.sync {
+            listenerCount = listenerImpressionsCount
+        }
+
+        XCTAssertGreaterThan(elapsedMs, 0)
+        XCTAssertEqual(trackedEvaluations, listenerCount,
+                       "Tracked evaluations should equal impression listener count")
+        XCTAssertTrue(trackedEvaluations <= dbCount + postedCount,
+                       "Tracked evaluations \(trackedEvaluations) should be equal or less than db + posted impressions (no loss) (\(dbCount) + \(postedCount))")
+
+        cleanupClient(client)
+    }
+
+    /**
+     Scenario: no impressions are lost when client is destroyed during in-flight post
+
+     Given an SDK client initialized with mocked split and segment endpoints
+     And impressions refresh rate set to 999 seconds (prevent automatic flush)
+     And the impressions HTTP endpoint is configured to block responses via semaphore
+     When getTreatment is called multiple times to generate impressions
+     And flush() is called to trigger impression posting
+     And the test waits for the HTTP post to start
+     And destroy() is called while the HTTP response is still blocked
+     Then no impressions should be orphaned in deleted status
+     And all impressions are accounted for: either posted or still active (recoverable).
+     */
+    func testImpressionsNotLostWhenDestroyedDuringInflightPost() {
+        let databaseName = "impressions_orphan_destroy_e2e"
+        let impressionPostStarted = XCTestExpectation(description: "Impression post started")
+        let impressionPostSemaphore = DispatchSemaphore(value: 0)
+        var postReceivedCount = 0
+        let postQueue = DispatchQueue(label: "orphan-test-post-queue")
+
+        let dispatcher = buildOrphanTestDispatcher { request in
+            impressionPostStarted.fulfill()
+            impressionPostSemaphore.wait()
+            postQueue.sync {
+                postReceivedCount += self.parseImpressionCount(from: request)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        let httpClient = buildOrphanHttpClient(dispatcher: dispatcher)
+        setupOrphanTestDatabase(name: databaseName)
+        let client = buildOrphanTestClient(httpClient: httpClient, matchingKey: userKey)
+
+        // Generate impressions
+        let evaluationCount = 200
+        generateImpressions(client: client, count: evaluationCount)
+        usleep(2_000_000)
+
+        // Verify impressions are in DB with active status
+        let (activeBeforeFlush, _) = queryImpressionCounts()
+        print("SplitSDK - ORPHAN_TEST activeBeforeFlush=\(activeBeforeFlush)")
+        XCTAssertEqual(evaluationCount, activeBeforeFlush, "All impressions should be active before flush")
+
+        // Trigger flush — this will pop() rows (marking them deleted) and start HTTP post
+        client.flush()
+        wait(for: [impressionPostStarted], timeout: 10)
+
+        // Destroy the client while the HTTP post is still blocked
+        cleanupClient(client)
+
+        // Check DB and post state BEFORE unblocking the HTTP response.
+        let (activeAfterDestroy, deletedAfterDestroy) = queryImpressionCounts()
+        var postReceivedAfterDestroy = 0
+        postQueue.sync { postReceivedAfterDestroy = postReceivedCount }
+
+        print("SplitSDK - ORPHAN_TEST activeAfterDestroy=\(activeAfterDestroy), deletedAfterDestroy=\(deletedAfterDestroy), postReceivedAfterDestroy=\(postReceivedAfterDestroy), evaluationCount=\(evaluationCount)")
+
+        // No impressions should be stuck in deleted status — they must be either
+        // posted successfully or restored to active so a future flush can retry them.
+        XCTAssertEqual(0, deletedAfterDestroy,
+                       "No impressions should be orphaned in deleted status")
+        XCTAssertEqual(evaluationCount, activeAfterDestroy + postReceivedAfterDestroy,
+                       "All impressions must be accounted for: either posted or still active")
+
+        // Unblock the HTTP response so the blocked worker thread can finish
+        impressionPostSemaphore.signal()
+        usleep(500_000)
+
+        removeDatabaseFiles(databaseName: databaseName)
+    }
+
+    /**
+     Scenario: a second client on the same DB recovers orphaned impressions from the first
+
+     This is a variant of testImpressionsNotLostWhenDestroyedDuringInflightPost.
+     After Client A's impressions are orphaned (stuck in deleted status), a second
+     factory/client is created on the same database. Client B does its own evaluations
+     and flushes. We verify that:
+     - Client B posts both its OWN and the recovered orphaned impressions from Client A
+     - No impressions remain in deleted status after Client B flushes
+     */
+    func testOrphanedImpressionsRecoveredByNewClient() {
+        let databaseName = "impressions_orphan_new_client_e2e"
+        let impressionPostStarted = XCTestExpectation(description: "Impression post started")
+        let impressionPostSemaphore = DispatchSemaphore(value: 0)
+        let clientBPostedExp = XCTestExpectation(description: "Client B impressions posted")
+        var postReceivedCount = 0
+        var clientBPostReceivedCount = 0
+        var isClientBPhase = false
+        let postQueue = DispatchQueue(label: "orphan-new-client-post-queue")
+
+        let dispatcher = buildOrphanTestDispatcher { request in
+            if !isClientBPhase {
+                // Client A phase: block the response
+                impressionPostStarted.fulfill()
+                impressionPostSemaphore.wait()
+                postQueue.sync {
+                    postReceivedCount += self.parseImpressionCount(from: request)
+                }
+                return TestDispatcherResponse(code: 200)
+            } else {
+                // Client B phase: respond immediately and count
+                postQueue.sync {
+                    clientBPostReceivedCount += self.parseImpressionCount(from: request)
+                }
+                clientBPostedExp.fulfill()
+                return TestDispatcherResponse(code: 200)
+            }
+        }
+
+        // --- Client A phase ---
+        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcher)
+        setupOrphanTestDatabase(name: databaseName)
+        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey)
+
+        let evaluationCountA = 200
+        generateImpressions(client: clientA, count: evaluationCountA)
+        usleep(2_000_000)
+
+        // Flush Client A → pop marks rows as deleted → HTTP blocks
+        clientA.flush()
+        wait(for: [impressionPostStarted], timeout: 10)
+
+        // Destroy Client A while HTTP is blocked
+        cleanupClient(clientA)
+
+        // Unblock the HTTP response (too late — destroy already happened)
+        impressionPostSemaphore.signal()
+        usleep(500_000)
+
+        // Verify Client A's impressions are orphaned
+        let (_, deletedAfterDestroy) = queryImpressionCounts()
+        print("SplitSDK - ORPHAN_NEW_CLIENT deletedAfterDestroy=\(deletedAfterDestroy)")
+
+        // --- Client B phase ---
+        isClientBPhase = true
+        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcher)
+        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key")
+
+        let evaluationCountB = 20
+        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
+        usleep(2_000_000)
+
+        // Flush Client B
+        clientB.flush()
+        wait(for: [clientBPostedExp], timeout: 15)
+        usleep(1_000_000)
+
+        // Final state
+        var finalClientBPostCount = 0
+        postQueue.sync { finalClientBPostCount = clientBPostReceivedCount }
+        let (finalActive, finalDeleted) = queryImpressionCounts()
+
+        print("SplitSDK - ORPHAN_NEW_CLIENT clientBPosted=\(finalClientBPostCount), finalActive=\(finalActive), finalDeleted=\(finalDeleted)")
+
+        // Client B should have posted ALL impressions: its own + recovered orphans from Client A
+        XCTAssertEqual(evaluationCountA + evaluationCountB, finalClientBPostCount,
+                       "Client B should post both its own and Client A's recovered impressions")
+
+        // No impressions should remain in deleted status
+        XCTAssertEqual(0, finalDeleted,
+                       "No impressions should be stuck in deleted status after Client B flushes")
+
+        removeDatabaseFiles(databaseName: databaseName)
+    }
+
+    /**
+     Scenario: a second client recovers impressions that failed to post from the first (no interruption)
+
+     Given Client A generates impressions and flushes
+     And the impressions HTTP POST fails with a 500 error (not interrupted)
+     And ImpressionsRecorderWorker.setActive() restores them to active status
+     And Client A is destroyed normally after the failed flush completes
+     When a second factory/client (Client B) is created on the same database
+     And Client B generates its own impressions and flushes
+     Then Client B posts both Client A's recovered impressions and its own
+     And no impressions remain in the database.
+     */
+    func testFailedImpressionsRecoveredByNewClient() {
+        let databaseName = "impressions_failed_recovery_e2e"
+        let clientAPostAttempted = XCTestExpectation(description: "Client A post attempted")
+        let clientBPostedAllExp = XCTestExpectation(description: "Client B posted all impressions")
+
+        let postQueue = DispatchQueue(label: "failed-recovery-post-queue")
+        var isClientBPhase = false
+        var clientBPostedCount = 0
+        var clientBExpFulfilled = false
+
+        let evaluationCountA = 50
+        let evaluationCountB = 20
+        let expectedTotalPostedByB = evaluationCountA + evaluationCountB
+
+        let dispatcher = buildOrphanTestDispatcher { request in
+            if !isClientBPhase {
+                // Client A phase: fail the POST with 500 (should be recovered by setActive()).
+                clientAPostAttempted.fulfill()
+                return TestDispatcherResponse(code: 500)
+            }
+
+            // Client B phase: succeed and count all impressions (Client A recovered + Client B generated).
+            postQueue.sync {
+                clientBPostedCount += self.parseImpressionCount(from: request)
+                if !clientBExpFulfilled && clientBPostedCount >= expectedTotalPostedByB {
+                    clientBExpFulfilled = true
+                    clientBPostedAllExp.fulfill()
+                }
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+
+        // --- Client A phase ---
+        setupOrphanTestDatabase(name: databaseName)
+        let httpClientA = buildOrphanHttpClient(dispatcher: dispatcher)
+        let clientA = buildOrphanTestClient(httpClient: httpClientA, matchingKey: userKey) { config in
+            // Deterministic: avoid queue-size-triggered flushes and keep A in a single chunk.
+            config.impressionsQueueSize = 10_000
+            config.impressionsChunkSize = 100
+        }
+
+        generateImpressions(client: clientA, count: evaluationCountA)
+        usleep(2_000_000)
+
+        clientA.flush()
+        wait(for: [clientAPostAttempted], timeout: 10)
+
+        // Wait until impressions are restored to active by setActive().
+        let restoreDeadline = Date().timeIntervalSince1970 + 10.0
+        while Date().timeIntervalSince1970 < restoreDeadline {
+            let (active, deleted) = queryImpressionCounts()
+            if active == evaluationCountA && deleted == 0 {
+                break
+            }
+            usleep(200_000)
+        }
+
+        let (activeAfterFailedFlush, deletedAfterFailedFlush) = queryImpressionCounts()
+        XCTAssertEqual(evaluationCountA, activeAfterFailedFlush,
+                       "All impressions should be restored to active after failed POST")
+        XCTAssertEqual(0, deletedAfterFailedFlush,
+                       "No impressions should remain in deleted status after failed POST")
+
+        cleanupClient(clientA)
+
+        // --- Client B phase ---
+        isClientBPhase = true
+        let httpClientB = buildOrphanHttpClient(dispatcher: dispatcher)
+        let clientB = buildOrphanTestClient(httpClient: httpClientB, matchingKey: "client_b_key") { config in
+            config.impressionsQueueSize = 10_000
+            config.impressionsChunkSize = 100
+        }
+
+        generateImpressions(client: clientB, count: evaluationCountB, startIndex: evaluationCountA)
+        usleep(2_000_000)
+
+        clientB.flush()
+        wait(for: [clientBPostedAllExp], timeout: 15)
+
+        // Wait until DB drains after successful post.
+        let drainDeadline = Date().timeIntervalSince1970 + 10.0
+        while Date().timeIntervalSince1970 < drainDeadline {
+            let (active, deleted) = queryImpressionCounts()
+            if active == 0 && deleted == 0 {
+                break
+            }
+            usleep(200_000)
+        }
+
+        postQueue.sync {
+            XCTAssertEqual(expectedTotalPostedByB, clientBPostedCount,
+                           "Client B should post both Client A's recovered and its own impressions")
+        }
+
+        let (finalActive, finalDeleted) = queryImpressionCounts()
+        XCTAssertEqual(0, finalActive, "No active impressions should remain after successful flush")
+        XCTAssertEqual(0, finalDeleted, "No deleted impressions should remain after successful flush")
+
+        cleanupClient(clientB)
+        removeDatabaseFiles(databaseName: databaseName)
     }
 
     func testImpressionsWithPropertiesAreNotDedupedInOptimizedMode() {
@@ -204,11 +604,17 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
     }
     
     private func setupClient(mode: String) -> SplitClient {
+        return setupClient(mode: mode, configCustomizer: nil)
+    }
+
+    private func setupClient(mode: String,
+                             configCustomizer: ((SplitClientConfig) -> Void)?) -> SplitClient {
         let notificationHelper = NotificationHelperStub()
         db = TestingHelper.createTestDatabase(name: "test")
 
         let splitConfig = createSplitConfig()
         splitConfig.impressionsMode = mode
+        configCustomizer?(splitConfig)
         
         let key: Key = Key(matchingKey: userKey)
         let builder = DefaultSplitFactoryBuilder()
@@ -234,6 +640,66 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         wait(for: [sdkReadyExpectation, sseExp], timeout: 20)
         
         return client
+    }
+
+    private func setupClientFileBacked(mode: String,
+                                       databaseName: String,
+                                       configCustomizer: ((SplitClientConfig) -> Void)?) -> SplitClient {
+        let notificationHelper = NotificationHelperStub()
+        db = createCleanFileBackedDatabase(name: databaseName)
+
+        let splitConfig = createSplitConfig()
+        splitConfig.impressionsMode = mode
+        configCustomizer?(splitConfig)
+
+        let key: Key = Key(matchingKey: userKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(db)
+        _ = builder.setNotificationHelper(notificationHelper)
+        let factory = builder.setApiKey(apiKey).setKey(key)
+            .setConfig(splitConfig).build()!
+
+        let client = factory.client
+        let sdkReadyExpectation = XCTestExpectation(description: "SDK READY Expectation")
+
+        client.on(event: SplitEvent.sdkReady) {
+            sdkReadyExpectation.fulfill()
+        }
+        client.on(event: SplitEvent.sdkReadyTimedOut) {
+            sdkReadyExpectation.fulfill()
+        }
+
+        wait(for: [sdkReadyExpectation, sseExp], timeout: 20)
+        return client
+    }
+
+    private func createCleanFileBackedDatabase(name: String) -> SplitDatabase {
+        removeDatabaseFiles(databaseName: name)
+        guard let helper = CoreDataHelperBuilder.build(databaseName: name) else {
+            fatalError("Failed to create file-backed test DB: \(name)")
+        }
+        return TestingHelper.createTestDatabase(name: name, helper: helper)
+    }
+
+    private func removeDatabaseFiles(databaseName: String) {
+        guard let cachesUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).last else {
+            return
+        }
+
+        let base = "\(databaseName).\(ServiceConstants.databaseExtension)"
+        let dbUrls = [
+            cachesUrl.appendingPathComponent(base),
+            cachesUrl.appendingPathComponent(base + "-wal"),
+            cachesUrl.appendingPathComponent(base + "-shm")
+        ]
+
+        for url in dbUrls {
+            if FileManager.default.fileExists(atPath: url.path) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
     
     private func setupClientWithImpressionListener(_ listener: @escaping SplitImpressionListener) -> SplitClient {
@@ -279,8 +745,6 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
         splitConfig.eventsQueueSize = 99999
         splitConfig.eventsPushRate = 99999
         splitConfig.logLevel = .verbose
-        splitConfig.impressionsQueueSize = 1
-        splitConfig.impressionsChunkSize = 1
         return splitConfig
     }
 
@@ -321,6 +785,7 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
 
                         if let tests = try? Json.decodeFrom(json: bodyString, to: [ImpressionsTest].self) {
                             for test in tests {
+                                self.postedImpressionsCount += test.keyImpressions.count
                                 var imps = [KeyImpression]()
                                 if let prevImp = self.impressions[test.testName] {
                                     imps.append(contentsOf: prevImp)
@@ -368,5 +833,110 @@ class ImpressionsPropertiesE2ETest: XCTestCase {
             return IntegrationHelper.emptySplitChanges(since: 99999, till: 99999)
         }
         return splitJson
+    }
+
+    // MARK: - Orphan Test Helpers
+
+    /// Parses the number of individual impressions from an HTTP request body.
+    private func parseImpressionCount(from request: HttpDataRequest) -> Int {
+        guard let body = request.body?.stringRepresentation.utf8 else { return 0 }
+        let bodyString = String(body)
+        guard let tests = try? Json.decodeFrom(json: bodyString, to: [ImpressionsTest].self) else { return 0 }
+        return tests.reduce(0) { $0 + $1.keyImpressions.count }
+    }
+
+    /// Builds a dispatcher that handles standard endpoints and delegates impressions to the given handler.
+    private func buildOrphanTestDispatcher(
+        impressionHandler: @escaping (HttpDataRequest) -> TestDispatcherResponse
+    ) -> HttpClientTestDispatcher {
+        return { request in
+            if request.isSplitEndpoint() {
+                if self.firstSplitHit {
+                    self.firstSplitHit = false
+                    return TestDispatcherResponse(code: 200, data: Data(self.loadSplitsChangeFile().utf8))
+                }
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptySplitChanges(since: 99999, till: 99999).utf8))
+            }
+            if request.isMySegmentsEndpoint() {
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.emptyMySegments.utf8))
+            }
+            if request.isAuthEndpoint() {
+                self.isSseAuthHit = true
+                return TestDispatcherResponse(code: 200, data: Data(IntegrationHelper.dummySseResponse().utf8))
+            }
+            if request.isImpressionsEndpoint() {
+                return impressionHandler(request)
+            }
+            if request.isImpressionsCountEndpoint() {
+                return TestDispatcherResponse(code: 200)
+            }
+            return TestDispatcherResponse(code: 200)
+        }
+    }
+
+    /// Creates an HttpClient from a dispatcher, with a fresh session and streaming handler.
+    private func buildOrphanHttpClient(dispatcher: @escaping HttpClientTestDispatcher) -> HttpClient {
+        let session = HttpSessionMock()
+        let reqManager = HttpRequestManagerTestDispatcher(dispatcher: dispatcher,
+                                                          streamingHandler: buildStreamingHandler())
+        return DefaultHttpClient(session: session, requestManager: reqManager)
+    }
+
+    /// Sets up a clean file-backed database for orphan tests.
+    private func setupOrphanTestDatabase(name: String) {
+        removeDatabaseFiles(databaseName: name)
+        guard let helper = CoreDataHelperBuilder.build(databaseName: name) else {
+            XCTFail("Failed to create file-backed DB")
+            return
+        }
+        db = TestingHelper.createTestDatabase(name: name, helper: helper)
+    }
+
+    /// Builds a SplitClient configured for orphan impression tests, resetting SSE/split state.
+    private func buildOrphanTestClient(httpClient: HttpClient,
+                                       matchingKey: String,
+                                       configCustomizer: ((SplitClientConfig) -> Void)? = nil) -> SplitClient {
+        firstSplitHit = true
+        sseExp = XCTestExpectation(description: "SSE conn")
+
+        let splitConfig = createSplitConfig()
+        splitConfig.impressionsMode = "OPTIMIZED"
+        splitConfig.impressionRefreshRate = 999
+        configCustomizer?(splitConfig)
+
+        let key = Key(matchingKey: matchingKey)
+        let builder = DefaultSplitFactoryBuilder()
+        _ = builder.setHttpClient(httpClient)
+        _ = builder.setReachabilityChecker(ReachabilityMock())
+        _ = builder.setTestDatabase(db)
+        _ = builder.setNotificationHelper(NotificationHelperStub())
+        let factory = builder.setApiKey(apiKey).setKey(key)
+            .setConfig(splitConfig).build()!
+
+        let client = factory.client
+
+        let sdkReadyExpectation = XCTestExpectation(description: "SDK READY")
+        client.on(event: SplitEvent.sdkReady) { sdkReadyExpectation.fulfill() }
+        client.on(event: SplitEvent.sdkReadyTimedOut) { sdkReadyExpectation.fulfill() }
+        wait(for: [sdkReadyExpectation, sseExp], timeout: 20)
+
+        return client
+    }
+
+    /// Generates impressions with unique properties by calling getTreatment in a loop.
+    private func generateImpressions(client: SplitClient, count: Int, startIndex: Int = 0) {
+        for i in 0..<count {
+            let properties: [String: Any] = ["iteration": startIndex + i]
+            let evalOptions = EvaluationOptions(properties: properties)
+            let treatment = client.getTreatment("FACUNDO_TEST", attributes: nil, evaluationOptions: evalOptions)
+            XCTAssertEqual("off", treatment, "Expected 'off' treatment")
+        }
+    }
+
+    /// Queries the database for impression counts grouped by status.
+    private func queryImpressionCounts() -> (active: Int, deleted: Int) {
+        let active = db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.active, maxRows: 1_000_000).count
+        let deleted = db.impressionDao.getBy(createdAt: 0, status: StorageRecordStatus.deleted, maxRows: 1_000_000).count
+        return (active, deleted)
     }
 }

--- a/SplitTests/Service/Impressions/ImpressionsRecorderWorkerTests.swift
+++ b/SplitTests/Service/Impressions/ImpressionsRecorderWorkerTests.swift
@@ -41,17 +41,21 @@ class ImpressionsRecorderWorkerTests: XCTestCase {
     }
 
     func testFailToSendSome() {
-        // Sent impressions have to be removed from storage
-        // Non sent have to appear as active in storage to try to send them again
+        // Sent impressions have to be removed from storage.
+        // The flush stops on the first failed batch; impressions from that batch and
+        // all subsequent ones remain in storage (still active, recoverable on next flush).
         impressionsRecorder.errorOccurredCallCount = 3
         for impression in dummyImpressions {
             persistentImpressionStorage.push(impression: impression)
         }
         worker.flush()
 
-        XCTAssertEqual(6, impressionsRecorder.executeCallCount)
-        XCTAssertEqual(2, persistentImpressionStorage.storedImpressions.count)
-        XCTAssertEqual(9, impressionsRecorder.impressionsSent.flatMap { $0.keyImpressions }.count)
+        // 11 impressions / 2 per push → 3 execute calls before the error:
+        //   call 1 (ok): 2 sent, deleted. call 2 (ok): 2 sent, deleted.
+        //   call 3 (error): loop breaks, 2 + 5 remaining = 7 still in storage.
+        XCTAssertEqual(3, impressionsRecorder.executeCallCount)
+        XCTAssertEqual(7, persistentImpressionStorage.storedImpressions.count)
+        XCTAssertEqual(4, impressionsRecorder.impressionsSent.flatMap { $0.keyImpressions }.count)
     }
 
     func testSendOneImpression() {

--- a/SplitTests/Storage/ImpressionDaoTest.swift
+++ b/SplitTests/Storage/ImpressionDaoTest.swift
@@ -75,11 +75,10 @@ class ImpressionDaoTest: XCTestCase {
 
         let loadedImpressions = dao.getBy(createdAt: 200, status: StorageRecordStatus.active, maxRows: 20)
         dao.update(ids: loadedImpressions.prefix(5).compactMap { return $0.storageId }, newStatus: StorageRecordStatus.deleted)
-        let active = dao.getBy(createdAt: 200, status: StorageRecordStatus.active, maxRows: 20)
-        let deleted = dao.getBy(createdAt: 200, status: StorageRecordStatus.deleted, maxRows: 20)
+        // getBy no longer filters by status, so all 10 impressions are returned regardless
+        let all = dao.getBy(createdAt: 200, status: StorageRecordStatus.active, maxRows: 20)
 
-        XCTAssertEqual(5, active.count)
-        XCTAssertEqual(5, deleted.count)
+        XCTAssertEqual(10, all.count)
     }
 
     func testLoadOutdated() {

--- a/SplitTests/Storage/PersistentImpressionsStorageTest.swift
+++ b/SplitTests/Storage/PersistentImpressionsStorageTest.swift
@@ -43,8 +43,8 @@ class PersistentImpressionsStorageTests: XCTestCase {
         let popped = impressionsStorage.pop(count: 100)
 
         XCTAssertEqual(impressionDao.getByImpressions.count, popped.count)
-        XCTAssertEqual(impressionDao.updatedImpressions.count, popped.count)
-        XCTAssertEqual(0, impressionDao.updatedImpressions.values.filter { $0 == StorageRecordStatus.active }.count)
+        XCTAssertEqual(0, impressionDao.updatedImpressions.count)
+        XCTAssertEqual(0, impressionDao.deletedImpressions.count)
     }
 
     func testDelete() {


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?

- Removed usage of status for impression entries. This eliminates the edge case of impressions remaining in deleted status when POST is interrupted. It also decreases number of writes during the flush operation to a third (impressions deleted on success only), reducing pressure on DB in high concurrency scenarios.

- Version 3.7.1