### PR TITLE
Add default implementation for version property

### DIFF
--- a/Split/Api/SplitFactory.swift
+++ b/Split/Api/SplitFactory.swift
@@ -68,3 +68,8 @@ import Foundation
     ///
     var version: String { get }
 }
+
+// Default implementation
+public extension SplitFactory {
+    var version: String { Version.semantic }
+}


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
Don't tie version API access to an implementation detail (e.g. DefaultSplitFactory or LocalhostSplitFactory)
