### PR TITLE
Refactor split name filtering for case insensitivity

### DIFF
--- a/Split/Api/DefaultSplitManager.swift
+++ b/Split/Api/DefaultSplitManager.swift
@@ -95,9 +95,8 @@ import Foundation
             }
         }
 
-        let splitName = featureName.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        let filtered = splits.filter { return ( splitName == $0.name?.lowercased() ) }
-        return filtered.count > 0 ? filtered[0] : nil
+        let splitName = featureName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return splits.first(where: { $0.name?.caseInsensitiveCompare(splitName) == .orderedSame })
     }
 }
 


### PR DESCRIPTION
# iOS SDK

## What did you accomplish?
Small code improvements
- Updated API for string comparison
- Small performance improvement avoiding converting the string to lower case
- Avoid filtering - go with greedy API of first(where:)
- 
## How do we test the changes introduced in this PR?
Regular tests should pass as is
